### PR TITLE
Switch main font from Inter to IBM Plex Sans

### DIFF
--- a/app/lab/prognosis-2100/(charts)/themes/dark-theme.ts
+++ b/app/lab/prognosis-2100/(charts)/themes/dark-theme.ts
@@ -16,7 +16,7 @@ export const darkTheme = {
   ]),
   textStyle: {
     // Setting fontFamily doesn't work for Canvas renderer.
-    // fontFamily: 'var(--font-inter), sans-serif',
+    // fontFamily: 'var(--font-sans), sans-serif',
     color: '#cbd5e1',
     fontSize: 12
   },
@@ -28,7 +28,7 @@ export const darkTheme = {
       fontSize: 16,
       fontWeight: 'normal'
       // Setting fontFamily doesn't work for Canvas renderer.
-      // fontFamily: 'var(--font-inter), sans-serif'
+      // fontFamily: 'var(--font-sans), sans-serif'
     },
     subtextStyle: {
       color: '#94a3b8',

--- a/app/lab/prognosis-2100/(charts)/themes/light-theme.ts
+++ b/app/lab/prognosis-2100/(charts)/themes/light-theme.ts
@@ -7,7 +7,7 @@ export const lightTheme = {
   textStyle: {
     fontSize: 12
     // Setting fontFamily doesn't work for Canvas renderer.
-    // fontFamily: 'var(--font-inter), sans-serif',
+    // fontFamily: 'var(--font-sans), sans-serif',
   },
   title: {
     padding: 20,
@@ -17,7 +17,7 @@ export const lightTheme = {
       fontSize: 16,
       fontWeight: 'normal'
       // Setting fontFamily doesn't work for Canvas renderer.
-      // fontFamily: 'var(--font-inter), sans-serif'
+      // fontFamily: 'var(--font-sans), sans-serif'
     },
     subtextStyle: {
       fontSize: 12

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ import 'styles/global.css';
 const ibmPlexSans = IBM_Plex_Sans({
   weight: ['400', '500', '600', '700'],
   subsets: ['latin'],
-  variable: '--font-inter'
+  variable: '--font-sans'
 });
 
 const ptSerif = PT_Serif({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 import { Metadata, Viewport } from 'next';
-import { Inter, PT_Serif } from 'next/font/google';
+import { IBM_Plex_Sans, PT_Serif } from 'next/font/google';
 import localFont from 'next/font/local';
 
 import { Body } from 'components/layout/Body';
@@ -8,7 +8,11 @@ import { Tracking } from 'components/Tracking';
 
 import 'styles/global.css';
 
-const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
+const ibmPlexSans = IBM_Plex_Sans({
+  weight: ['400', '500', '600', '700'],
+  subsets: ['latin'],
+  variable: '--font-inter'
+});
 
 const ptSerif = PT_Serif({
   weight: ['400', '700'],
@@ -101,7 +105,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
       lang="en"
       suppressHydrationWarning={true}
       data-scroll-behavior="smooth"
-      className={`${ptSerif.variable} ${inter.variable} ${nimbus.variable} h-full min-w-[360px] scroll-smooth font-sans`}
+      className={`${ptSerif.variable} ${ibmPlexSans.variable} ${nimbus.variable} h-full min-w-[360px] scroll-smooth font-sans`}
     >
       <link rel="me" href="https://hachyderm.io/@vnglst" />
       <link rel="alternate" type="application/rss+xml" href="https://koenvangilst.nl/feed.xml" />

--- a/styles/global.css
+++ b/styles/global.css
@@ -20,7 +20,7 @@
   --color-blue-800: #1565c0;
 
   --font-family-sans:
-    var(--font-inter), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    var(--font-sans), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
     'Noto Color Emoji';
   --font-family-serif: var(--font-serif), ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
   --font-family-nimbus: var(--font-nimbus), ui-sans-serif, system-ui, sans-serif;


### PR DESCRIPTION
Replace the Inter font with IBM Plex Sans for the main sans-serif font.
Includes weights 400, 500, 600, and 700 for better typography flexibility.
The CSS variable name remains --font-inter for backward compatibility.