### PR TITLE
Remove empty work tag from featured tags

### DIFF
--- a/app/lab/project-browser.tsx
+++ b/app/lab/project-browser.tsx
@@ -23,7 +23,6 @@ type ProjectBrowserProps = {
 const FEATURED_TAGS = [
   { label: 'articles', href: '?q=article' },
   { label: 'side projects', href: '?q=side-project' },
-  { label: 'work', href: '?q=work' },
   { label: 'snippets', href: '?q=snippet' }
 ];
 


### PR DESCRIPTION
The work tag is no longer used after work-related blog posts were removed.