### PR TITLE
Fix code snippet width overflow on smaller screens

### DIFF
--- a/components/layout/Container.tsx
+++ b/components/layout/Container.tsx
@@ -27,7 +27,7 @@ export function Container({
               <Link href="/">Koen van Gilst</Link>
             </div>
           )}
-          <div className="w-full md:w-9/12">{children}</div>
+          <div className="w-full min-w-0 md:w-9/12">{children}</div>
           {footer && <Footer />}
         </Suspense>
       </Main>

--- a/styles/prose.css
+++ b/styles/prose.css
@@ -1,7 +1,15 @@
 /* Prose component and typography overrides */
 
+.prose {
+  @apply min-w-0;
+}
+
 .prose svg {
   max-width: 100%;
+}
+
+.prose pre {
+  @apply overflow-x-auto max-w-full;
 }
 
 .prose .anchor {

--- a/styles/prose.css
+++ b/styles/prose.css
@@ -9,7 +9,14 @@
 }
 
 .prose pre {
-  @apply overflow-x-auto max-w-full;
+  max-width: calc(100vw - 2rem);
+  overflow-x: auto;
+}
+
+@media (min-width: 768px) {
+  .prose pre {
+    max-width: 100%;
+  }
 }
 
 .prose .anchor {

--- a/styles/prose.css
+++ b/styles/prose.css
@@ -9,8 +9,9 @@
 }
 
 .prose pre {
-  max-width: calc(100vw - 2rem);
+  max-width: calc(100vw - 4rem);
   overflow-x: auto;
+  box-sizing: border-box;
 }
 
 @media (min-width: 768px) {

--- a/styles/syntax-highlighting.css
+++ b/styles/syntax-highlighting.css
@@ -65,7 +65,7 @@ code[class*='language-'] {
 }
 
 pre[class*='language-'] {
-  @apply overflow-x-auto max-w-full;
+  @apply max-w-full overflow-x-auto;
 }
 
 /* Subtle scrollbar styling */

--- a/styles/syntax-highlighting.css
+++ b/styles/syntax-highlighting.css
@@ -65,8 +65,9 @@ code[class*='language-'] {
 }
 
 pre[class*='language-'] {
-  max-width: calc(100vw - 2rem);
+  max-width: calc(100vw - 4rem);
   overflow-x: auto;
+  box-sizing: border-box;
 }
 
 @media (min-width: 768px) {

--- a/styles/syntax-highlighting.css
+++ b/styles/syntax-highlighting.css
@@ -64,12 +64,34 @@ code[class*='language-'] {
   @apply border-none p-0;
 }
 
+pre[class*='language-'] {
+  @apply overflow-x-auto max-w-full;
+}
+
+/* Subtle scrollbar styling */
 pre::-webkit-scrollbar {
-  display: none;
+  height: 8px;
+}
+
+pre::-webkit-scrollbar-track {
+  @apply bg-gray-100 dark:bg-gray-800;
+}
+
+pre::-webkit-scrollbar-thumb {
+  @apply bg-gray-300 dark:bg-gray-600 rounded;
+}
+
+pre::-webkit-scrollbar-thumb:hover {
+  @apply bg-gray-400 dark:bg-gray-500;
 }
 
 pre {
-  scrollbar-width: none; /* Firefox */
+  scrollbar-width: thin; /* Firefox */
+  scrollbar-color: rgb(209 213 219) rgb(243 244 246); /* gray-300 on gray-100 */
+}
+
+.dark pre {
+  scrollbar-color: rgb(75 85 99) rgb(31 41 55); /* gray-600 on gray-800 */
 }
 
 .rehype-code-title {
@@ -81,8 +103,7 @@ pre {
 }
 
 .code-highlight {
-  float: left;
-  min-width: 100%;
+  @apply block w-full;
 }
 
 .highlight-line {

--- a/styles/syntax-highlighting.css
+++ b/styles/syntax-highlighting.css
@@ -65,7 +65,14 @@ code[class*='language-'] {
 }
 
 pre[class*='language-'] {
-  @apply max-w-full overflow-x-auto;
+  max-width: calc(100vw - 2rem);
+  overflow-x: auto;
+}
+
+@media (min-width: 768px) {
+  pre[class*='language-'] {
+    max-width: 100%;
+  }
 }
 
 /* Subtle scrollbar styling */


### PR DESCRIPTION
- Add overflow-x-auto and max-w-full to ensure code blocks stay within screen bounds
- Replace hidden scrollbars with subtle, styled scrollbars for better UX
- Fix .code-highlight layout by removing float and using block display
- Resolves horizontal scrollbar issue on mobile/smaller screens