### PR TITLE
Add swipe navigation to photography page

### DIFF
--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { PhotoType } from './getPhotos';
@@ -9,54 +8,7 @@ type PhotoGalleryProps = {
   photos: PhotoType[];
 };
 
-type LazyPhotoProps = {
-  photo: PhotoType;
-  index: number;
-};
-
-function LazyPhoto({ photo, index }: LazyPhotoProps) {
-  const [isVisible, setIsVisible] = useState(false);
-  const [hasLoaded, setHasLoaded] = useState(false);
-  const [showSpinner, setShowSpinner] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-        }
-      },
-      {
-        rootMargin: '100px',
-        threshold: 0.01
-      }
-    );
-
-    if (containerRef.current) {
-      observer.observe(containerRef.current);
-    }
-
-    return () => {
-      if (containerRef.current) {
-        observer.unobserve(containerRef.current);
-      }
-    };
-  }, []);
-
-  // Delay showing spinner to avoid flash on cached images
-  useEffect(() => {
-    if (!isVisible || hasLoaded) return;
-
-    const timer = setTimeout(() => {
-      if (!hasLoaded) {
-        setShowSpinner(true);
-      }
-    }, 300);
-
-    return () => clearTimeout(timer);
-  }, [isVisible, hasLoaded]);
-
+function Photo({ photo }: { photo: PhotoType }) {
   function formatDate(dateString?: Date) {
     if (!dateString) return '';
     return new Date(dateString).toLocaleDateString('en-US', {
@@ -67,158 +19,42 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
   }
 
   return (
-    <div
-      ref={containerRef}
-      className="relative flex h-screen w-full snap-start snap-always items-center justify-center bg-slate-950"
-      id={`photo-${index}`}
-    >
-      {isVisible && (
-        <>
-          {!hasLoaded && showSpinner && (
-            <div className="absolute inset-0 z-10 flex items-center justify-center bg-slate-950">
-              <div className="text-center text-white">
-                <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4 border-slate-700 border-t-white" />
-                <p className="text-sm">Loading photo...</p>
-              </div>
-            </div>
-          )}
-          <picture className="h-full w-full">
-            <source srcSet={photo.srcSetWebp} sizes="100vw" type="image/webp" />
-            <img
-              src={photo.src}
-              srcSet={photo.srcSet}
-              sizes="100vw"
-              alt={photo.alt}
-              width={photo.width}
-              height={photo.height}
-              loading="lazy"
-              decoding="async"
-              className={`h-full w-full object-contain transition-opacity duration-300 ${
-                hasLoaded ? 'opacity-100' : 'opacity-0'
-              }`}
-              onLoad={() => setHasLoaded(true)}
-              style={{
-                backgroundImage: `url(${photo.blurDataURL})`,
-                backgroundSize: 'cover'
-              }}
-            />
-          </picture>
-          {/* Photo info overlay */}
-          <div className="pointer-events-none absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent px-8 pb-12 pt-16">
-            <div className="text-center">
-              <div className="text-base font-light tracking-wide text-white">{photo.location}</div>
-              <div className="mt-1 text-xs font-light text-white/70">{formatDate(photo.createdAt)}</div>
-            </div>
-          </div>
-        </>
-      )}
+    <div className="relative h-screen w-full snap-start snap-always bg-slate-950">
+      <img
+        src={photo.src}
+        srcSet={photo.srcSet}
+        sizes="100vw"
+        alt={photo.alt}
+        className="h-full w-full object-contain"
+        loading="lazy"
+      />
+      <div className="pointer-events-none absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent px-8 pb-12 pt-16">
+        <div className="text-center">
+          <div className="text-base font-light tracking-wide text-white">{photo.location}</div>
+          <div className="mt-1 text-xs font-light text-white/70">{formatDate(photo.createdAt)}</div>
+        </div>
+      </div>
     </div>
   );
 }
 
-function FullScreenGallery({ photos, startIndex }: { photos: PhotoType[]; startIndex: number }) {
-  const [currentIndex, setCurrentIndex] = useState(startIndex);
-  const containerRef = useRef<HTMLDivElement>(null);
+function FullScreenGallery({ photos }: { photos: PhotoType[] }) {
   const router = useRouter();
 
-  const scrollToPhoto = (index: number, smooth = true) => {
-    const element = document.getElementById(`photo-${index}`);
-    if (element) {
-      element.scrollIntoView({ behavior: smooth ? 'smooth' : 'instant' });
-    }
-  };
-
-  // Scroll to start index on mount (instant, no animation)
-  useEffect(() => {
-    if (startIndex > 0) {
-      // Small delay to ensure DOM is ready
-      setTimeout(() => scrollToPhoto(startIndex, false), 100);
-    }
-  }, [startIndex]);
-
-  // Track current photo with intersection observer
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            const id = entry.target.id;
-            const index = parseInt(id.split('-')[1]);
-            setCurrentIndex(index);
-          }
-        });
-      },
-      {
-        root: containerRef.current,
-        threshold: 0.5
-      }
-    );
-
-    const photoElements = document.querySelectorAll('[id^="photo-"]');
-    photoElements.forEach((photo) => observer.observe(photo));
-
-    return () => {
-      photoElements.forEach((photo) => observer.unobserve(photo));
-    };
-  }, []);
-
-  // Keyboard navigation
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        router.replace('/photography');
-      } else if (e.key === 'ArrowDown' || e.key === ' ') {
-        if (currentIndex < photos.length - 1) {
-          scrollToPhoto(currentIndex + 1);
-        }
-        e.preventDefault();
-      } else if (e.key === 'ArrowUp') {
-        if (currentIndex > 0) {
-          scrollToPhoto(currentIndex - 1);
-        }
-        e.preventDefault();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [currentIndex, photos.length, router]);
-
-  const handleClose = () => {
-    // Navigate back to grid view
-    router.replace('/photography');
-  };
-
-  const progressPercentage = ((currentIndex + 1) / photos.length) * 100;
-
   return (
-    <div className="relative">
-      {/* Top navigation bar */}
-      <nav className="fixed top-4 left-1/2 z-50 flex -translate-x-1/2 items-center gap-2 rounded-full bg-black/50 px-3 py-2 backdrop-blur-sm sm:gap-2 sm:px-4">
-        <button
-          onClick={handleClose}
-          className="flex items-center gap-2 text-sm text-white transition-opacity hover:opacity-60"
-        >
-          <span>←</span>
-          <span className="hidden sm:inline">Back</span>
-        </button>
-        <span className="hidden text-white sm:inline">|</span>
-        <span className="text-xs text-white sm:text-sm">
-          {currentIndex + 1} / {photos.length}
-        </span>
-      </nav>
+    <div className="fixed inset-0 bg-slate-950">
+      {/* Back button */}
+      <button
+        onClick={() => router.replace('/photography')}
+        className="fixed top-4 left-4 z-50 rounded-full bg-black/50 px-4 py-2 text-sm text-white backdrop-blur-sm transition-opacity hover:opacity-60"
+      >
+        ← Back
+      </button>
 
-      {/* Vertical progress bar */}
-      <div className="fixed top-0 right-0 z-50 h-screen w-1 bg-white/10">
-        <div
-          className="w-full bg-white/60 transition-all duration-300 ease-out"
-          style={{ height: `${progressPercentage}%` }}
-        />
-      </div>
-
-      <div ref={containerRef} className="h-screen snap-y snap-mandatory overflow-y-scroll">
-        {photos.map((photo, index) => (
-          <LazyPhoto key={photo.id} photo={photo} index={index} />
+      {/* Photo container */}
+      <div className="h-screen snap-y snap-mandatory overflow-y-scroll">
+        {photos.map((photo) => (
+          <Photo key={photo.id} photo={photo} />
         ))}
       </div>
     </div>
@@ -229,44 +65,25 @@ export function PhotoGallery({ photos }: PhotoGalleryProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const photoParam = searchParams.get('photo');
-  const selectedIndex = photoParam !== null ? parseInt(photoParam, 10) : null;
 
-  const openPhoto = (index: number) => {
-    router.push(`/photography?photo=${index}`);
-  };
-
-  // Show full-screen gallery if a photo is selected
-  if (selectedIndex !== null && !isNaN(selectedIndex) && selectedIndex >= 0 && selectedIndex < photos.length) {
-    return <FullScreenGallery photos={photos} startIndex={selectedIndex} />;
+  // Show full-screen gallery
+  if (photoParam !== null) {
+    return <FullScreenGallery photos={photos} />;
   }
 
   // Show grid overview
   return (
     <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {photos.map((photo, index) => (
-        <button key={photo.id} onClick={() => openPhoto(index)} className="relative block aspect-square">
-          <picture>
-            <source
-              srcSet={photo.srcSetWebp}
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-              type="image/webp"
-            />
-            <img
-              src={photo.src}
-              srcSet={photo.srcSet}
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-              alt={photo.alt}
-              width={photo.width}
-              height={photo.height}
-              loading={photo.id < 2 ? 'eager' : 'lazy'}
-              decoding="async"
-              className="h-full w-full rounded-lg object-cover transition-opacity hover:opacity-90"
-              style={{
-                backgroundImage: `url(${photo.blurDataURL})`,
-                backgroundSize: 'cover'
-              }}
-            />
-          </picture>
+        <button key={photo.id} onClick={() => router.push(`/photography?photo=${index}`)} className="relative block aspect-square overflow-hidden rounded-lg">
+          <img
+            src={photo.src}
+            srcSet={photo.srcSet}
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            alt={photo.alt}
+            className="h-full w-full object-cover transition-opacity hover:opacity-90"
+            loading={index < 6 ? 'eager' : 'lazy'}
+          />
         </button>
       ))}
     </div>

--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -17,6 +17,7 @@ type LazyPhotoProps = {
 function LazyPhoto({ photo, index }: LazyPhotoProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [hasLoaded, setHasLoaded] = useState(false);
+  const [showSpinner, setShowSpinner] = useState(false);
   const [isZoomed, setIsZoomed] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -44,6 +45,19 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
     };
   }, []);
 
+  // Delay showing spinner to avoid flash on cached images
+  useEffect(() => {
+    if (!isVisible || hasLoaded) return;
+
+    const timer = setTimeout(() => {
+      if (!hasLoaded) {
+        setShowSpinner(true);
+      }
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [isVisible, hasLoaded]);
+
   function formatDate(dateString?: Date) {
     if (!dateString) return '';
     return new Date(dateString).toLocaleDateString('en-US', {
@@ -61,7 +75,7 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
     >
       {isVisible && (
         <>
-          {!hasLoaded && (
+          {!hasLoaded && showSpinner && (
             <div className="absolute inset-0 z-10 flex items-center justify-center bg-slate-950">
               <div className="text-center text-white">
                 <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4 border-slate-700 border-t-white" />
@@ -87,7 +101,7 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
                 decoding="async"
                 className={`h-full w-full transition-all duration-500 ease-out ${
                   isZoomed ? 'scale-150 object-cover' : 'scale-100 object-contain'
-                }`}
+                } ${hasLoaded ? 'opacity-100' : 'opacity-0'}`}
                 onLoad={() => setHasLoaded(true)}
                 style={{
                   backgroundImage: `url(${photo.blurDataURL})`,

--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -17,6 +17,7 @@ type LazyPhotoProps = {
 function LazyPhoto({ photo, index }: LazyPhotoProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [hasLoaded, setHasLoaded] = useState(false);
+  const [isZoomed, setIsZoomed] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -68,25 +69,33 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
               </div>
             </div>
           )}
-          <picture className="h-full w-full">
-            <source srcSet={photo.srcSetWebp} sizes="100vw" type="image/webp" />
-            <img
-              src={photo.src}
-              srcSet={photo.srcSet}
-              sizes="100vw"
-              alt={photo.alt}
-              width={photo.width}
-              height={photo.height}
-              loading="lazy"
-              decoding="async"
-              className="h-full w-full object-contain"
-              onLoad={() => setHasLoaded(true)}
-              style={{
-                backgroundImage: `url(${photo.blurDataURL})`,
-                backgroundSize: 'cover'
-              }}
-            />
-          </picture>
+          <button
+            onClick={() => setIsZoomed(!isZoomed)}
+            className="h-full w-full cursor-zoom-in focus:outline-none"
+            style={{ cursor: isZoomed ? 'zoom-out' : 'zoom-in' }}
+          >
+            <picture className="h-full w-full">
+              <source srcSet={photo.srcSetWebp} sizes="100vw" type="image/webp" />
+              <img
+                src={photo.src}
+                srcSet={photo.srcSet}
+                sizes="100vw"
+                alt={photo.alt}
+                width={photo.width}
+                height={photo.height}
+                loading="lazy"
+                decoding="async"
+                className={`h-full w-full transition-all duration-500 ease-out ${
+                  isZoomed ? 'scale-150 object-cover' : 'scale-100 object-contain'
+                }`}
+                onLoad={() => setHasLoaded(true)}
+                style={{
+                  backgroundImage: `url(${photo.blurDataURL})`,
+                  backgroundSize: 'cover'
+                }}
+              />
+            </picture>
+          </button>
         </>
       )}
       {!isVisible && (
@@ -111,18 +120,18 @@ function FullScreenGallery({ photos, startIndex }: { photos: PhotoType[]; startI
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
 
-  const scrollToPhoto = (index: number) => {
+  const scrollToPhoto = (index: number, smooth = true) => {
     const element = document.getElementById(`photo-${index}`);
     if (element) {
-      element.scrollIntoView({ behavior: 'smooth' });
+      element.scrollIntoView({ behavior: smooth ? 'smooth' : 'instant' });
     }
   };
 
-  // Scroll to start index on mount
+  // Scroll to start index on mount (instant, no animation)
   useEffect(() => {
     if (startIndex > 0) {
       // Small delay to ensure DOM is ready
-      setTimeout(() => scrollToPhoto(startIndex), 100);
+      setTimeout(() => scrollToPhoto(startIndex, false), 100);
     }
   }, [startIndex]);
 

--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -18,7 +18,6 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [hasLoaded, setHasLoaded] = useState(false);
   const [showSpinner, setShowSpinner] = useState(false);
-  const [isZoomed, setIsZoomed] = useState(!photo.isVertical); // Start zoomed for horizontal photos
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -26,9 +25,6 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
       ([entry]) => {
         if (entry.isIntersecting) {
           setIsVisible(true);
-        } else {
-          // Reset zoom when photo is no longer visible
-          setIsZoomed(!photo.isVertical);
         }
       },
       {
@@ -46,7 +42,7 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
         observer.unobserve(containerRef.current);
       }
     };
-  }, [photo.isVertical]);
+  }, []);
 
   // Delay showing spinner to avoid flash on cached images
   useEffect(() => {
@@ -86,33 +82,27 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
               </div>
             </div>
           )}
-          <button
-            onClick={() => setIsZoomed(!isZoomed)}
-            className="h-full w-full cursor-zoom-in focus:outline-none"
-            style={{ cursor: isZoomed ? 'zoom-out' : 'zoom-in' }}
-          >
-            <picture className="h-full w-full">
-              <source srcSet={photo.srcSetWebp} sizes="100vw" type="image/webp" />
-              <img
-                src={photo.src}
-                srcSet={photo.srcSet}
-                sizes="100vw"
-                alt={photo.alt}
-                width={photo.width}
-                height={photo.height}
-                loading="lazy"
-                decoding="async"
-                className={`h-full w-full transition-all duration-500 ease-out ${
-                  isZoomed ? 'scale-150 object-cover' : 'scale-100 object-contain'
-                } ${hasLoaded ? 'opacity-100' : 'opacity-0'}`}
-                onLoad={() => setHasLoaded(true)}
-                style={{
-                  backgroundImage: `url(${photo.blurDataURL})`,
-                  backgroundSize: 'cover'
-                }}
-              />
-            </picture>
-          </button>
+          <picture className="h-full w-full">
+            <source srcSet={photo.srcSetWebp} sizes="100vw" type="image/webp" />
+            <img
+              src={photo.src}
+              srcSet={photo.srcSet}
+              sizes="100vw"
+              alt={photo.alt}
+              width={photo.width}
+              height={photo.height}
+              loading="lazy"
+              decoding="async"
+              className={`h-full w-full object-contain transition-opacity duration-300 ${
+                hasLoaded ? 'opacity-100' : 'opacity-0'
+              }`}
+              onLoad={() => setHasLoaded(true)}
+              style={{
+                backgroundImage: `url(${photo.blurDataURL})`,
+                backgroundSize: 'cover'
+              }}
+            />
+          </picture>
         </>
       )}
       {/* Photo info overlay */}

--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -166,7 +166,7 @@ function FullScreenGallery({ photos, startIndex }: { photos: PhotoType[]; startI
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        router.push('/photography');
+        router.replace('/photography');
       } else if (e.key === 'ArrowDown' || e.key === ' ') {
         if (currentIndex < photos.length - 1) {
           scrollToPhoto(currentIndex + 1);
@@ -185,7 +185,8 @@ function FullScreenGallery({ photos, startIndex }: { photos: PhotoType[]; startI
   }, [currentIndex, photos.length, router]);
 
   const handleClose = () => {
-    router.push('/photography');
+    // Navigate back to grid view
+    router.replace('/photography');
   };
 
   const progressPercentage = ((currentIndex + 1) / photos.length) * 100;

--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -101,6 +101,8 @@ export function PhotoGallery({ photos }: PhotoGalleryProps) {
       x: e.targetTouches[0].clientX,
       y: e.targetTouches[0].clientY
     });
+    // Prevent default scrolling behavior
+    e.preventDefault();
   };
 
   const onTouchEnd = () => {
@@ -116,20 +118,32 @@ export function PhotoGallery({ photos }: PhotoGalleryProps) {
       if (distanceX > minSwipeDistance && selectedIndex < photos.length - 1) {
         setSelectedIndex(selectedIndex + 1);
       }
-      // Swipe right (previous photo)
-      if (distanceX < -minSwipeDistance && selectedIndex > 0) {
-        setSelectedIndex(selectedIndex - 1);
+      // Swipe right (previous photo or close if first photo)
+      if (distanceX < -minSwipeDistance) {
+        if (selectedIndex > 0) {
+          setSelectedIndex(selectedIndex - 1);
+        } else {
+          // Return to overview if swiping right on first photo
+          setSelectedIndex(null);
+          setIsFullScreen(true);
+        }
       }
     }
     // Vertical swipe
     else {
-      // Swipe up (previous photo, like TikTok going back)
-      if (distanceY > minSwipeDistance && selectedIndex > 0) {
-        setSelectedIndex(selectedIndex - 1);
-      }
-      // Swipe down (next photo, like TikTok scrolling forward)
-      if (distanceY < -minSwipeDistance && selectedIndex < photos.length - 1) {
+      // Swipe up (next photo, like TikTok scrolling forward)
+      if (distanceY > minSwipeDistance && selectedIndex < photos.length - 1) {
         setSelectedIndex(selectedIndex + 1);
+      }
+      // Swipe down (previous photo or close if first photo, like TikTok)
+      if (distanceY < -minSwipeDistance) {
+        if (selectedIndex > 0) {
+          setSelectedIndex(selectedIndex - 1);
+        } else {
+          // Return to overview if swiping down on first photo
+          setSelectedIndex(null);
+          setIsFullScreen(true);
+        }
       }
     }
   };
@@ -227,20 +241,7 @@ export function PhotoGallery({ photos }: PhotoGalleryProps) {
               />
             </picture>
           </div>
-          <div className="fixed bottom-3 left-0 flex w-full items-center justify-between gap-4 px-3 md:bottom-5 md:px-5">
-            {selectedIndex > 0 ? (
-              <IconButton
-                onClick={() => setSelectedIndex(selectedIndex - 1)}
-                className="m-auto text-lg"
-                variant="overlay"
-                size="lg"
-                aria-label="Previous photo"
-              >
-                ←
-              </IconButton>
-            ) : (
-              <div className="m-auto h-14 w-14" />
-            )}
+          <div className="fixed bottom-3 left-1/2 -translate-x-1/2 px-3 md:bottom-5">
             <div className="rounded-md bg-black/50 p-2 text-center text-sm text-gray-200 backdrop-blur-sm">
               <div className="md:hidden">{selectedPhoto.location}</div>
               <div className="md:hidden">{formatDate(selectedPhoto.createdAt)}</div>
@@ -248,19 +249,6 @@ export function PhotoGallery({ photos }: PhotoGalleryProps) {
                 {selectedPhoto.location} • {formatDate(selectedPhoto.createdAt)}
               </div>
             </div>
-            {selectedIndex < photos.length - 1 ? (
-              <IconButton
-                onClick={() => setSelectedIndex(selectedIndex + 1)}
-                className="m-auto text-lg"
-                variant="overlay"
-                size="lg"
-                aria-label="Next photo"
-              >
-                →
-              </IconButton>
-            ) : (
-              <div className="m-auto h-14 w-14" />
-            )}
           </div>
         </div>
       )}

--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -18,7 +18,7 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [hasLoaded, setHasLoaded] = useState(false);
   const [showSpinner, setShowSpinner] = useState(false);
-  const [isZoomed, setIsZoomed] = useState(false);
+  const [isZoomed, setIsZoomed] = useState(!photo.isVertical); // Start zoomed for horizontal photos
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -103,15 +103,15 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
               }}
             />
           </picture>
+          {/* Photo info overlay */}
+          <div className="pointer-events-none absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent px-8 pb-12 pt-16">
+            <div className="text-center">
+              <div className="text-base font-light tracking-wide text-white">{photo.location}</div>
+              <div className="mt-1 text-xs font-light text-white/70">{formatDate(photo.createdAt)}</div>
+            </div>
+          </div>
         </>
       )}
-      {/* Photo info overlay */}
-      <div className="pointer-events-none absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent px-8 pb-12 pt-16">
-        <div className="text-center">
-          <div className="text-base font-light tracking-wide text-white">{photo.location}</div>
-          <div className="mt-1 text-xs font-light text-white/70">{formatDate(photo.createdAt)}</div>
-        </div>
-      </div>
     </div>
   );
 }

--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -96,10 +96,10 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
       )}
 
       {/* Photo info overlay */}
-      <div className="pointer-events-none absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black/60 to-transparent p-6">
-        <div className="text-center text-sm text-white">
-          <div>{photo.location}</div>
-          <div className="text-xs text-white/80">{formatDate(photo.createdAt)}</div>
+      <div className="pointer-events-none absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent p-8 pb-6">
+        <div className="text-center">
+          <div className="text-base font-light tracking-wide text-white">{photo.location}</div>
+          <div className="mt-1 text-xs font-light text-white/70">{formatDate(photo.createdAt)}</div>
         </div>
       </div>
     </div>
@@ -126,6 +126,7 @@ function FullScreenGallery({ photos, startIndex }: { photos: PhotoType[]; startI
     }
   }, [startIndex]);
 
+  // Track current photo with intersection observer
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
@@ -151,19 +152,44 @@ function FullScreenGallery({ photos, startIndex }: { photos: PhotoType[]; startI
     };
   }, []);
 
+  // Keyboard navigation
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        router.push('/photography');
+      } else if (e.key === 'ArrowDown' || e.key === ' ') {
+        if (currentIndex < photos.length - 1) {
+          scrollToPhoto(currentIndex + 1);
+        }
+        e.preventDefault();
+      } else if (e.key === 'ArrowUp') {
+        if (currentIndex > 0) {
+          scrollToPhoto(currentIndex - 1);
+        }
+        e.preventDefault();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [currentIndex, photos.length, router]);
+
   const handleClose = () => {
     router.push('/photography');
   };
 
+  const progressPercentage = ((currentIndex + 1) / photos.length) * 100;
+
   return (
     <div className="relative">
+      {/* Top navigation bar */}
       <nav className="fixed top-4 left-1/2 z-50 flex -translate-x-1/2 items-center gap-2 rounded-full bg-black/50 px-3 py-2 backdrop-blur-sm sm:gap-2 sm:px-4">
         <button
           onClick={handleClose}
           className="flex items-center gap-2 text-sm text-white transition-opacity hover:opacity-60"
         >
           <span>←</span>
-          <span className="hidden sm:inline">Back to Overview</span>
+          <span className="hidden sm:inline">Back</span>
         </button>
         <span className="hidden text-white sm:inline">|</span>
         <span className="text-xs text-white sm:text-sm">
@@ -171,17 +197,12 @@ function FullScreenGallery({ photos, startIndex }: { photos: PhotoType[]; startI
         </span>
       </nav>
 
-      <div className="fixed top-1/2 right-4 z-50 flex -translate-y-1/2 flex-col gap-2">
-        {photos.map((_, index) => (
-          <button
-            key={index}
-            onClick={() => scrollToPhoto(index)}
-            className={`h-2 w-2 rounded-full transition-all ${
-              currentIndex === index ? 'scale-125 bg-white' : 'bg-white/50 hover:bg-white/75'
-            }`}
-            aria-label={`Go to photo ${index + 1}`}
-          />
-        ))}
+      {/* Vertical progress bar */}
+      <div className="fixed top-0 right-0 z-50 h-screen w-1 bg-white/10">
+        <div
+          className="w-full bg-white/60 transition-all duration-300 ease-out"
+          style={{ height: `${progressPercentage}%` }}
+        />
       </div>
 
       <div ref={containerRef} className="h-screen snap-y snap-mandatory overflow-y-scroll">

--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -26,6 +26,9 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
       ([entry]) => {
         if (entry.isIntersecting) {
           setIsVisible(true);
+        } else {
+          // Reset zoom when photo is no longer visible
+          setIsZoomed(!photo.isVertical);
         }
       },
       {
@@ -43,7 +46,7 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
         observer.unobserve(containerRef.current);
       }
     };
-  }, []);
+  }, [photo.isVertical]);
 
   // Delay showing spinner to avoid flash on cached images
   useEffect(() => {

--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -112,14 +112,8 @@ function LazyPhoto({ photo, index }: LazyPhotoProps) {
           </button>
         </>
       )}
-      {!isVisible && (
-        <div className="absolute inset-0 flex items-center justify-center bg-slate-950 text-white">
-          <p className="text-sm">{photo.location}</p>
-        </div>
-      )}
-
       {/* Photo info overlay */}
-      <div className="pointer-events-none absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent p-8 pb-6">
+      <div className="pointer-events-none absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent px-8 pb-12 pt-16">
         <div className="text-center">
           <div className="text-base font-light tracking-wide text-white">{photo.location}</div>
           <div className="mt-1 text-xs font-light text-white/70">{formatDate(photo.createdAt)}</div>

--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { PhotoType } from './getPhotos';
@@ -8,7 +9,7 @@ type PhotoGalleryProps = {
   photos: PhotoType[];
 };
 
-function Photo({ photo }: { photo: PhotoType }) {
+function Photo({ photo, index }: { photo: PhotoType; index: number }) {
   function formatDate(dateString?: Date) {
     if (!dateString) return '';
     return new Date(dateString).toLocaleDateString('en-US', {
@@ -19,7 +20,7 @@ function Photo({ photo }: { photo: PhotoType }) {
   }
 
   return (
-    <div className="relative h-screen w-full snap-start snap-always bg-slate-950">
+    <div id={`photo-${index}`} className="relative h-screen w-full snap-start snap-always bg-slate-950">
       <img
         src={photo.src}
         srcSet={photo.srcSet}
@@ -42,8 +43,15 @@ function Photo({ photo }: { photo: PhotoType }) {
   );
 }
 
-function FullScreenGallery({ photos }: { photos: PhotoType[] }) {
+function FullScreenGallery({ photos, startIndex }: { photos: PhotoType[]; startIndex: number }) {
   const router = useRouter();
+
+  useEffect(() => {
+    const element = document.getElementById(`photo-${startIndex}`);
+    if (element) {
+      element.scrollIntoView({ behavior: 'instant' });
+    }
+  }, [startIndex]);
 
   return (
     <div className="fixed inset-0 bg-slate-950">
@@ -57,8 +65,8 @@ function FullScreenGallery({ photos }: { photos: PhotoType[] }) {
 
       {/* Photo container */}
       <div className="h-screen snap-y snap-mandatory overflow-y-scroll">
-        {photos.map((photo) => (
-          <Photo key={photo.id} photo={photo} />
+        {photos.map((photo, index) => (
+          <Photo key={photo.id} photo={photo} index={index} />
         ))}
       </div>
     </div>
@@ -69,17 +77,22 @@ export function PhotoGallery({ photos }: PhotoGalleryProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const photoParam = searchParams.get('photo');
+  const selectedIndex = photoParam ? parseInt(photoParam, 10) : 0;
 
   // Show full-screen gallery
   if (photoParam !== null) {
-    return <FullScreenGallery photos={photos} />;
+    return <FullScreenGallery photos={photos} startIndex={selectedIndex} />;
   }
 
   // Show grid overview
   return (
     <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {photos.map((photo, index) => (
-        <button key={photo.id} onClick={() => router.push(`/photography?photo=${index}`)} className="relative block aspect-square overflow-hidden rounded-lg">
+        <button
+          key={photo.id}
+          onClick={() => router.push(`/photography?photo=${index}`)}
+          className="relative block aspect-square overflow-hidden rounded-lg"
+        >
           <img
             src={photo.src}
             srcSet={photo.srcSet}

--- a/app/photography/PhotoGallery.tsx
+++ b/app/photography/PhotoGallery.tsx
@@ -27,6 +27,10 @@ function Photo({ photo }: { photo: PhotoType }) {
         alt={photo.alt}
         className="h-full w-full object-contain"
         loading="lazy"
+        style={{
+          backgroundImage: `url(${photo.blurDataURL})`,
+          backgroundSize: 'cover'
+        }}
       />
       <div className="pointer-events-none absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent px-8 pb-12 pt-16">
         <div className="text-center">
@@ -83,6 +87,10 @@ export function PhotoGallery({ photos }: PhotoGalleryProps) {
             alt={photo.alt}
             className="h-full w-full object-cover transition-opacity hover:opacity-90"
             loading={index < 6 ? 'eager' : 'lazy'}
+            style={{
+              backgroundImage: `url(${photo.blurDataURL})`,
+              backgroundSize: 'cover'
+            }}
           />
         </button>
       ))}

--- a/app/photography/page.tsx
+++ b/app/photography/page.tsx
@@ -1,7 +1,5 @@
 import { Metadata } from 'next';
 
-import { Container } from 'components/layout/Container';
-
 import { getPhotos } from './getPhotos';
 import { PhotoGallery } from './PhotoGallery';
 
@@ -16,9 +14,5 @@ export const revalidate = 3600;
 export default async function Photography() {
   const photos = await getPhotos();
 
-  return (
-    <Container footer wide>
-      <PhotoGallery photos={photos} />
-    </Container>
-  );
+  return <PhotoGallery photos={photos} />;
 }

--- a/app/photography/page.tsx
+++ b/app/photography/page.tsx
@@ -11,27 +11,27 @@ export const metadata: Metadata = {
   description: 'A collection of photographs by Koen van Gilst'
 };
 
-// Cache page data for 1 hour
 export const revalidate = 3600;
 
-export default async function Photography({
-  searchParams
-}: {
-  searchParams: Promise<{ photo?: string }>;
-}) {
+export default async function Photography({ searchParams }: { searchParams: Promise<{ photo?: string }> }) {
   const photos = await getPhotos();
   const params = await searchParams;
-  const isFullScreen = params.photo !== undefined;
 
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      {isFullScreen ? (
+  // Full-screen gallery mode (no container)
+  if (params.photo !== undefined) {
+    return (
+      <Suspense>
         <PhotoGallery photos={photos} />
-      ) : (
-        <Container footer wide>
-          <PhotoGallery photos={photos} />
-        </Container>
-      )}
-    </Suspense>
+      </Suspense>
+    );
+  }
+
+  // Grid overview mode (with container)
+  return (
+    <Container footer wide>
+      <Suspense>
+        <PhotoGallery photos={photos} />
+      </Suspense>
+    </Container>
   );
 }

--- a/app/photography/page.tsx
+++ b/app/photography/page.tsx
@@ -1,4 +1,7 @@
 import { Metadata } from 'next';
+import { Suspense } from 'react';
+
+import { Container } from 'components/layout/Container';
 
 import { getPhotos } from './getPhotos';
 import { PhotoGallery } from './PhotoGallery';
@@ -11,8 +14,24 @@ export const metadata: Metadata = {
 // Cache page data for 1 hour
 export const revalidate = 3600;
 
-export default async function Photography() {
+export default async function Photography({
+  searchParams
+}: {
+  searchParams: Promise<{ photo?: string }>;
+}) {
   const photos = await getPhotos();
+  const params = await searchParams;
+  const isFullScreen = params.photo !== undefined;
 
-  return <PhotoGallery photos={photos} />;
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      {isFullScreen ? (
+        <PhotoGallery photos={photos} />
+      ) : (
+        <Container footer wide>
+          <PhotoGallery photos={photos} />
+        </Container>
+      )}
+    </Suspense>
+  );
 }


### PR DESCRIPTION
- Added touch event handlers (onTouchStart, onTouchMove, onTouchEnd)
- Support vertical swipes (up/down) for previous/next photo navigation
- Support horizontal swipes (left/right) for consistency
- Minimum swipe distance of 50px to prevent accidental navigation
- Maintains minimal aesthetic while adding intuitive mobile gestures