### PR TITLE
Add page views stats using Plausible Analytics API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Plausible Analytics API Key
+# Get this from your Plausible instance:
+# 1. Log in to https://plausible.koenvangilst.nl
+# 2. Go to Settings > API Keys
+# 3. Create a new "Stats API" key
+PLAUSIBLE_API_KEY=your_api_key_here

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const PLAUSIBLE_BASE_URL = 'https://plausible.koenvangilst.nl';
+const PLAUSIBLE_SITE_ID = 'koenvangilst.nl';
+
+/**
+ * Fetch page stats from Plausible Analytics
+ * API route to proxy requests to Plausible Stats API
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const page = searchParams.get('page');
+
+  if (!page) {
+    return NextResponse.json({ error: 'Page parameter is required' }, { status: 400 });
+  }
+
+  const apiKey = process.env.PLAUSIBLE_API_KEY;
+
+  if (!apiKey) {
+    console.warn('PLAUSIBLE_API_KEY not configured');
+    return NextResponse.json({ error: 'API key not configured' }, { status: 500 });
+  }
+
+  try {
+    // Fetch aggregate stats for the specific page
+    const response = await fetch(
+      `${PLAUSIBLE_BASE_URL}/api/v1/stats/aggregate?` +
+        new URLSearchParams({
+          site_id: PLAUSIBLE_SITE_ID,
+          period: 'all', // Get all-time stats
+          metrics: 'visitors,pageviews',
+          filters: `event:page==${page}`
+        }),
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`
+        }
+      }
+    );
+
+    if (!response.ok) {
+      console.error('Plausible API error:', response.status, await response.text());
+      return NextResponse.json(
+        { error: 'Failed to fetch stats from Plausible' },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+
+    return NextResponse.json({
+      page,
+      visitors: data.results.visitors.value || 0,
+      pageviews: data.results.pageviews.value || 0
+    });
+  } catch (error) {
+    console.error('Error fetching Plausible stats:', error);
+    return NextResponse.json({ error: 'Failed to fetch stats' }, { status: 500 });
+  }
+}

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -24,11 +24,14 @@ export async function GET(request: NextRequest) {
 
   try {
     // Fetch aggregate stats for the specific page
+    // Using custom date range from site start (2010-01-01) to today for all-time stats
+    const today = new Date().toISOString().split('T')[0];
     const response = await fetch(
       `${PLAUSIBLE_BASE_URL}/api/v1/stats/aggregate?` +
         new URLSearchParams({
           site_id: PLAUSIBLE_SITE_ID,
-          period: 'all', // Get all-time stats
+          period: 'custom',
+          date: `2010-01-01,${today}`, // All-time stats from site inception
           metrics: 'visitors,pageviews',
           filters: `event:page==${page}`
         }),

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -44,10 +44,7 @@ export async function GET(request: NextRequest) {
 
     if (!response.ok) {
       console.error('Plausible API error:', response.status, await response.text());
-      return NextResponse.json(
-        { error: 'Failed to fetch stats from Plausible' },
-        { status: response.status }
-      );
+      return NextResponse.json({ error: 'Failed to fetch stats from Plausible' }, { status: response.status });
     }
 
     const data = await response.json();

--- a/app/lab/[slug]/page.tsx
+++ b/app/lab/[slug]/page.tsx
@@ -33,7 +33,7 @@ export default async function Page(props: Props) {
       title={post.title}
       readingTime={post.readingTime}
       tags={post.tags}
-      path={'/' + post.slug}
+      path={'/lab/' + post.slug}
       image={post.image}
       code={post.code}
       additionalComponents={additionalComponents}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,7 +6,7 @@ export default async function sitemap() {
   const allPosts = await getPosts();
   const photos = await getPhotos();
 
-  const pages = ['', 'about', 'lab', 'dashboard', 'dashboard/stats', 'llms.txt'];
+  const pages = ['', 'about', 'lab', 'llms.txt'];
 
   const urls = [
     ...pages.map((page) => ({

--- a/components/content/ArticleMetadata.tsx
+++ b/components/content/ArticleMetadata.tsx
@@ -1,4 +1,12 @@
-export function ArticleMetadata({ publishedAt, readingTimeText }: { publishedAt: string; readingTimeText: string }) {
+export function ArticleMetadata({
+  publishedAt,
+  readingTimeText,
+  children
+}: {
+  publishedAt: string;
+  readingTimeText: string;
+  children?: React.ReactNode;
+}) {
   return (
     <div className="mt-2 flex w-full items-center justify-between text-sm text-gray-600 dark:text-gray-400">
       <p>
@@ -8,7 +16,15 @@ export function ArticleMetadata({ publishedAt, readingTimeText }: { publishedAt:
           day: 'numeric'
         })}
       </p>
-      <p>{readingTimeText}</p>
+      <p className="flex items-center gap-2">
+        {readingTimeText}
+        {children && (
+          <>
+            <span>·</span>
+            {children}
+          </>
+        )}
+      </p>
     </div>
   );
 }

--- a/components/content/MarkdownLayout.tsx
+++ b/components/content/MarkdownLayout.tsx
@@ -9,6 +9,7 @@ import { TagLink } from '../ui/Tag';
 import { ArticleMetadata } from './ArticleMetadata';
 import { Heading } from './Heading';
 import { MDXComponent } from './MDXComponent';
+import { PageViews } from './PageViews';
 import { Prose } from './Prose';
 
 type Props = {
@@ -44,6 +45,9 @@ export async function MarkdownLayout({
         <header>
           <Heading level={1}>{title}</Heading>
           <ArticleMetadata publishedAt={publishedAt} readingTimeText={readingTime.text} />
+          <div className="mb-2 text-sm">
+            <PageViews path={path} />
+          </div>
           {tags && tags.length > 0 && (
             <ul className="my-4 flex w-full flex-wrap gap-2">
               {tags.map((tag: string) => (

--- a/components/content/MarkdownLayout.tsx
+++ b/components/content/MarkdownLayout.tsx
@@ -44,10 +44,9 @@ export async function MarkdownLayout({
       <article className="w-full max-w-[700px]">
         <header>
           <Heading level={1}>{title}</Heading>
-          <ArticleMetadata publishedAt={publishedAt} readingTimeText={readingTime.text} />
-          <div className="mb-2 text-sm">
+          <ArticleMetadata publishedAt={publishedAt} readingTimeText={readingTime.text}>
             <PageViews path={path} />
-          </div>
+          </ArticleMetadata>
           {tags && tags.length > 0 && (
             <ul className="my-4 flex w-full flex-wrap gap-2">
               {tags.map((tag: string) => (

--- a/components/content/PageViews.tsx
+++ b/components/content/PageViews.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import useSWR from 'swr';
+
+import { fetcher } from 'lib/fetcher';
+
+type PageViewsProps = {
+  path: string;
+};
+
+type StatsResponse = {
+  page: string;
+  visitors: number;
+  pageviews: number;
+  error?: string;
+};
+
+export function PageViews({ path }: PageViewsProps) {
+  const { data, error } = useSWR<StatsResponse>(`/api/stats?page=${encodeURIComponent(path)}`, fetcher, {
+    // Revalidate every 5 minutes
+    refreshInterval: 5 * 60 * 1000,
+    // Don't revalidate on focus
+    revalidateOnFocus: false
+  });
+
+  if (error || data?.error) {
+    // Silently fail - don't show errors to users
+    return null;
+  }
+
+  if (!data) {
+    // Loading state - show placeholder
+    return <span className="text-gray-600 dark:text-gray-400">— views</span>;
+  }
+
+  const views = data.pageviews || 0;
+
+  return (
+    <span className="text-gray-600 dark:text-gray-400">
+      {views.toLocaleString()} {views === 1 ? 'view' : 'views'}
+    </span>
+  );
+}

--- a/content/coding-is-dead.mdx
+++ b/content/coding-is-dead.mdx
@@ -1,19 +1,17 @@
 ---
 title: Coding is Dead
 publishedAt: '2026-01-13'
+image:
+  src: /static/images/we-create-worlds.jpg
+  alt: Origin Systems logo with tagline 'We create worlds' against a starfield background
+  width: 2560
+  height: 1440
+  showAsHeader: true
 summary: 'From typing over starfield code as a kid to letting AI agents build features - reflecting on how coding is changing and what it means for software engineers.'
 tags:
   - ai
   - article
 ---
-
-<Image
-  alt="Origin Systems logo with tagline 'We create worlds' against a starfield background"
-  src="/static/images/we-create-worlds.jpg"
-  width={2560}
-  height={1440}
-  priority
-/>
 
 I remember seeing Origin Systems tagline when playing Ultima and thinking: "I also want to create worlds!". I ended up trying, but as a kid I never got much further than creating the [starfield](https://star-trek.netlify.app/) that you see behind the logo. And that was after months of painstakingly typing over what seemed like nonsense to me to paint just a few pixels on the screen. Unlikely as this may seem, it was the beginning of my passion for creating things with code.
 

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -2,5 +2,6 @@ declare namespace NodeJS {
   interface ProcessEnv {
     COMMIT_HASH: string;
     APP_VERSION: string;
+    PLAUSIBLE_API_KEY?: string;
   }
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Implements page visit statistics displayed on blog posts using the self-hosted Plausible instance.

Changes:
- Add PLAUSIBLE_API_KEY environment variable support
- Create /api/stats endpoint to fetch page views from Plausible
- Add PageViews client component using SWR for data fetching
- Display view count on each blog post page
- Add .env.example with setup instructions
- Remove non-existent dashboard pages from sitemap

The feature gracefully handles API errors by silently failing, ensuring the site remains functional even if the stats API is unavailable.