### PR TITLE
Add dashboard page with visitor statistics

### DIFF
--- a/app/api/dashboard-stats/aggregate/route.ts
+++ b/app/api/dashboard-stats/aggregate/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const PLAUSIBLE_BASE_URL = 'https://plausible.koenvangilst.nl';
+const PLAUSIBLE_SITE_ID = 'koenvangilst.nl';
+
+interface AggregateStats {
+  visitors: number;
+  pageviews: number;
+  bounce_rate: number;
+  visit_duration: number;
+}
+
+/**
+ * Fetch aggregate stats from Plausible Analytics
+ * API route to proxy requests to Plausible Stats API
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const period = searchParams.get('period') || '30d';
+
+  const apiKey = process.env.PLAUSIBLE_API_KEY;
+
+  if (!apiKey) {
+    console.warn('PLAUSIBLE_API_KEY not configured');
+    return NextResponse.json({ error: 'API key not configured' }, { status: 500 });
+  }
+
+  try {
+    let dateParam: string | undefined;
+    const today = new Date().toISOString().split('T')[0];
+
+    if (period === 'all') {
+      dateParam = `2010-01-01,${today}`;
+    }
+
+    // Fetch aggregate stats
+    const params: Record<string, string> = {
+      site_id: PLAUSIBLE_SITE_ID,
+      period: period === 'all' ? 'custom' : period,
+      metrics: 'visitors,pageviews,bounce_rate,visit_duration'
+    };
+
+    if (dateParam) {
+      params.date = dateParam;
+    }
+
+    const response = await fetch(
+      `${PLAUSIBLE_BASE_URL}/api/v1/stats/aggregate?${new URLSearchParams(params)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`
+        }
+      }
+    );
+
+    if (!response.ok) {
+      console.error('Plausible API error:', response.status, await response.text());
+      return NextResponse.json({ error: 'Failed to fetch stats from Plausible' }, { status: response.status });
+    }
+
+    const data = await response.json();
+
+    const stats: AggregateStats = {
+      visitors: data.results.visitors?.value || 0,
+      pageviews: data.results.pageviews?.value || 0,
+      bounce_rate: data.results.bounce_rate?.value || 0,
+      visit_duration: data.results.visit_duration?.value || 0
+    };
+
+    return NextResponse.json({
+      period,
+      stats
+    });
+  } catch (error) {
+    console.error('Error fetching Plausible stats:', error);
+    return NextResponse.json({ error: 'Failed to fetch stats' }, { status: 500 });
+  }
+}

--- a/app/api/dashboard-stats/route.ts
+++ b/app/api/dashboard-stats/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const PLAUSIBLE_BASE_URL = 'https://plausible.koenvangilst.nl';
+const PLAUSIBLE_SITE_ID = 'koenvangilst.nl';
+
+type TimePeriod = 'all' | 'year' | 'month' | 'week';
+
+interface PageStat {
+  page: string;
+  visitors: number;
+  pageviews: number;
+}
+
+/**
+ * Fetch top pages from Plausible Analytics for different time periods
+ * API route to proxy requests to Plausible Stats API
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const period = (searchParams.get('period') || 'all') as TimePeriod;
+  const limit = parseInt(searchParams.get('limit') || '10', 10);
+
+  const apiKey = process.env.PLAUSIBLE_API_KEY;
+
+  if (!apiKey) {
+    console.warn('PLAUSIBLE_API_KEY not configured');
+    return NextResponse.json({ error: 'API key not configured' }, { status: 500 });
+  }
+
+  try {
+    // Determine date range based on period
+    let periodParam: string;
+    let dateParam: string | undefined;
+    const today = new Date().toISOString().split('T')[0];
+
+    switch (period) {
+      case 'all':
+        periodParam = 'custom';
+        dateParam = `2010-01-01,${today}`; // All-time stats from site inception
+        break;
+      case 'year':
+        periodParam = '12mo';
+        dateParam = undefined;
+        break;
+      case 'month':
+        periodParam = 'month';
+        dateParam = undefined;
+        break;
+      case 'week':
+        periodParam = '7d';
+        dateParam = undefined;
+        break;
+      default:
+        return NextResponse.json({ error: 'Invalid period' }, { status: 400 });
+    }
+
+    // Fetch breakdown stats for pages
+    const params: Record<string, string> = {
+      site_id: PLAUSIBLE_SITE_ID,
+      period: periodParam,
+      property: 'event:page',
+      metrics: 'visitors,pageviews',
+      limit: limit.toString()
+    };
+
+    if (dateParam) {
+      params.date = dateParam;
+    }
+
+    const response = await fetch(
+      `${PLAUSIBLE_BASE_URL}/api/v1/stats/breakdown?${new URLSearchParams(params)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`
+        }
+      }
+    );
+
+    if (!response.ok) {
+      console.error('Plausible API error:', response.status, await response.text());
+      return NextResponse.json({ error: 'Failed to fetch stats from Plausible' }, { status: response.status });
+    }
+
+    const data = await response.json();
+
+    // Transform the response to a more convenient format
+    const results: PageStat[] = data.results.map((item: any) => ({
+      page: item.page,
+      visitors: item.visitors || 0,
+      pageviews: item.pageviews || 0
+    }));
+
+    return NextResponse.json({
+      period,
+      results
+    });
+  } catch (error) {
+    console.error('Error fetching Plausible stats:', error);
+    return NextResponse.json({ error: 'Failed to fetch stats' }, { status: 500 });
+  }
+}

--- a/app/api/dashboard-stats/timeseries/route.ts
+++ b/app/api/dashboard-stats/timeseries/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const PLAUSIBLE_BASE_URL = 'https://plausible.koenvangilst.nl';
+const PLAUSIBLE_SITE_ID = 'koenvangilst.nl';
+
+type TimePeriod = '7d' | '30d' | '12mo' | '6mo';
+
+interface TimeseriesDataPoint {
+  date: string;
+  visitors: number;
+  pageviews: number;
+}
+
+/**
+ * Fetch timeseries data from Plausible Analytics for charts
+ * API route to proxy requests to Plausible Stats API
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const period = (searchParams.get('period') || '30d') as TimePeriod;
+
+  const apiKey = process.env.PLAUSIBLE_API_KEY;
+
+  if (!apiKey) {
+    console.warn('PLAUSIBLE_API_KEY not configured');
+    return NextResponse.json({ error: 'API key not configured' }, { status: 500 });
+  }
+
+  try {
+    // Fetch timeseries stats
+    const params: Record<string, string> = {
+      site_id: PLAUSIBLE_SITE_ID,
+      period: period,
+      metrics: 'visitors,pageviews'
+    };
+
+    const response = await fetch(
+      `${PLAUSIBLE_BASE_URL}/api/v1/stats/timeseries?${new URLSearchParams(params)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`
+        }
+      }
+    );
+
+    if (!response.ok) {
+      console.error('Plausible API error:', response.status, await response.text());
+      return NextResponse.json({ error: 'Failed to fetch stats from Plausible' }, { status: response.status });
+    }
+
+    const data = await response.json();
+
+    // Transform the response to a more convenient format
+    const results: TimeseriesDataPoint[] = data.results.map((item: any) => ({
+      date: item.date,
+      visitors: item.visitors || 0,
+      pageviews: item.pageviews || 0
+    }));
+
+    return NextResponse.json({
+      period,
+      results
+    });
+  } catch (error) {
+    console.error('Error fetching Plausible stats:', error);
+    return NextResponse.json({ error: 'Failed to fetch stats' }, { status: 500 });
+  }
+}

--- a/app/dashboard/AggregateStats.tsx
+++ b/app/dashboard/AggregateStats.tsx
@@ -33,20 +33,17 @@ export function AggregateStats({ period = '30d' }: AggregateStatsProps) {
 
   if (error || data?.error) {
     return (
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <div className="col-span-full text-red-600 dark:text-red-400">Failed to load stats</div>
+      <div className="grid gap-3 md:gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="col-span-full text-red-600 dark:text-red-400 p-4">Failed to load stats</div>
       </div>
     );
   }
 
   if (!data) {
     return (
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-3 md:gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
         {[...Array(4)].map((_, i) => (
-          <div
-            key={i}
-            className="bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800 p-6 shadow-sm"
-          >
+          <div key={i} className="border border-dashed border-gray-400 dark:border-none p-4 md:p-6">
             <div className="animate-pulse space-y-3">
               <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded w-24"></div>
               <div className="h-8 bg-gray-200 dark:bg-gray-800 rounded w-32"></div>
@@ -64,12 +61,12 @@ export function AggregateStats({ period = '30d' }: AggregateStatsProps) {
   };
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+    <div className="grid gap-3 md:gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
       <StatsCard
         title="Total Visitors"
         value={data.stats.visitors.toLocaleString()}
         icon={
-          <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-6 h-6 md:w-8 md:h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               strokeLinecap="round"
               strokeLinejoin="round"
@@ -83,7 +80,7 @@ export function AggregateStats({ period = '30d' }: AggregateStatsProps) {
         title="Page Views"
         value={data.stats.pageviews.toLocaleString()}
         icon={
-          <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-6 h-6 md:w-8 md:h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               strokeLinecap="round"
               strokeLinejoin="round"
@@ -103,7 +100,7 @@ export function AggregateStats({ period = '30d' }: AggregateStatsProps) {
         title="Bounce Rate"
         value={`${data.stats.bounce_rate.toFixed(1)}%`}
         icon={
-          <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-6 h-6 md:w-8 md:h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               strokeLinecap="round"
               strokeLinejoin="round"
@@ -117,7 +114,7 @@ export function AggregateStats({ period = '30d' }: AggregateStatsProps) {
         title="Avg. Visit Duration"
         value={formatDuration(data.stats.visit_duration)}
         icon={
-          <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-6 h-6 md:w-8 md:h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               strokeLinecap="round"
               strokeLinejoin="round"

--- a/app/dashboard/AggregateStats.tsx
+++ b/app/dashboard/AggregateStats.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import useSWR from 'swr';
+import { fetcher } from 'lib/fetcher';
+import { StatsCard } from './StatsCard';
+
+type AggregateStatsData = {
+  visitors: number;
+  pageviews: number;
+  bounce_rate: number;
+  visit_duration: number;
+};
+
+type AggregateStatsResponse = {
+  period: string;
+  stats: AggregateStatsData;
+  error?: string;
+};
+
+type AggregateStatsProps = {
+  period?: string;
+};
+
+export function AggregateStats({ period = '30d' }: AggregateStatsProps) {
+  const { data, error } = useSWR<AggregateStatsResponse>(
+    `/api/dashboard-stats/aggregate?period=${period}`,
+    fetcher,
+    {
+      refreshInterval: 5 * 60 * 1000,
+      revalidateOnFocus: false
+    }
+  );
+
+  if (error || data?.error) {
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <div className="col-span-full text-red-600 dark:text-red-400">Failed to load stats</div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <div
+            key={i}
+            className="bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800 p-6 shadow-sm"
+          >
+            <div className="animate-pulse space-y-3">
+              <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded w-24"></div>
+              <div className="h-8 bg-gray-200 dark:bg-gray-800 rounded w-32"></div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const formatDuration = (seconds: number) => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes}m ${remainingSeconds}s`;
+  };
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <StatsCard
+        title="Total Visitors"
+        value={data.stats.visitors.toLocaleString()}
+        icon={
+          <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+            />
+          </svg>
+        }
+      />
+      <StatsCard
+        title="Page Views"
+        value={data.stats.pageviews.toLocaleString()}
+        icon={
+          <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+            />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+            />
+          </svg>
+        }
+      />
+      <StatsCard
+        title="Bounce Rate"
+        value={`${data.stats.bounce_rate.toFixed(1)}%`}
+        icon={
+          <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
+            />
+          </svg>
+        }
+      />
+      <StatsCard
+        title="Avg. Visit Duration"
+        value={formatDuration(data.stats.visit_duration)}
+        icon={
+          <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        }
+      />
+    </div>
+  );
+}

--- a/app/dashboard/Chart.tsx
+++ b/app/dashboard/Chart.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { memo, useEffect, useRef, useState } from 'react';
+import type * as echartsType from 'echarts/core';
+import type { ECBasicOption } from 'echarts/types/dist/shared';
+
+import { Theme, useTheme } from 'components/theme/theme.store';
+
+const darkTheme = {
+  darkMode: true,
+  color: ['#2196f3', '#42a5f5', '#64b5f6', '#1976d2', '#1565c0'],
+  backgroundColor: 'transparent',
+  textStyle: {
+    color: '#cbd5e1',
+    fontSize: 12
+  },
+  title: {
+    textStyle: {
+      color: '#fff',
+      fontSize: 16,
+      fontWeight: 'normal'
+    },
+    subtextStyle: {
+      color: '#94a3b8',
+      fontSize: 12
+    }
+  },
+  grid: {
+    top: '15%',
+    left: '3%',
+    right: '4%',
+    bottom: '10%',
+    containLabel: true
+  },
+  toolbox: {
+    iconStyle: {
+      borderColor: '#fff'
+    }
+  },
+  legend: {
+    textStyle: {
+      color: '#fff'
+    }
+  }
+};
+
+const lightTheme = {
+  darkMode: false,
+  color: ['#2196f3', '#42a5f5', '#64b5f6', '#1976d2', '#1565c0'],
+  backgroundColor: 'transparent',
+  textStyle: {
+    fontSize: 12
+  },
+  title: {
+    textStyle: {
+      color: '#000',
+      fontSize: 16,
+      fontWeight: 'normal'
+    },
+    subtextStyle: {
+      fontSize: 12
+    }
+  },
+  grid: {
+    top: '15%',
+    left: '3%',
+    right: '4%',
+    bottom: '10%',
+    containLabel: true
+  },
+  toolbox: {
+    iconStyle: {
+      borderColor: '#000'
+    }
+  },
+  legend: {
+    textStyle: {
+      color: '#000'
+    }
+  }
+};
+
+const DEFAULT_OPTIONS: ECBasicOption = {
+  toolbox: {
+    feature: {
+      saveAsImage: {
+        title: 'Save',
+        show: true
+      }
+    },
+    right: 15,
+    top: 15
+  }
+};
+
+type ChartProps = {
+  options: ECBasicOption;
+  className: string;
+};
+
+const ChartComponent = ({ options, className }: ChartProps) => {
+  const mode = useTheme((state) => state.theme);
+  const chartRef = useRef<HTMLDivElement>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!chartRef.current) return;
+
+    let chart: ReturnType<typeof echartsType.init> | null = null;
+
+    const loadChart = async () => {
+      const [
+        echarts,
+        { BarChart, LineChart },
+        {
+          GridComponent,
+          LegendComponent,
+          TitleComponent,
+          ToolboxComponent,
+          TooltipComponent,
+          DataZoomComponent
+        },
+        { CanvasRenderer }
+      ] = await Promise.all([
+        import('echarts/core'),
+        import('echarts/charts'),
+        import('echarts/components'),
+        import('echarts/renderers')
+      ]);
+
+      echarts.use([
+        BarChart,
+        LineChart,
+        LegendComponent,
+        GridComponent,
+        CanvasRenderer,
+        TitleComponent,
+        ToolboxComponent,
+        TooltipComponent,
+        DataZoomComponent
+      ]);
+
+      echarts.registerTheme(Theme.Light, lightTheme);
+      echarts.registerTheme(Theme.Dark, darkTheme);
+
+      if (!chartRef.current) return;
+
+      chart = echarts.init(chartRef.current, mode, { renderer: 'canvas' });
+
+      // Merge options
+      const mergedOptions = {
+        ...DEFAULT_OPTIONS,
+        ...options
+      };
+
+      chart.setOption(mergedOptions);
+      setIsLoading(false);
+
+      const handleResize = () => chart?.resize();
+      window.addEventListener('resize', handleResize);
+
+      return () => {
+        window.removeEventListener('resize', handleResize);
+      };
+    };
+
+    const cleanup = loadChart();
+
+    return () => {
+      cleanup.then((cleanupFn) => cleanupFn?.());
+      chart?.dispose();
+    };
+  }, [mode, options]);
+
+  return (
+    <div className="relative">
+      {isLoading && (
+        <div className={`${className} flex items-center justify-center bg-gray-100 dark:bg-gray-900`}>
+          <div className="text-gray-500 dark:text-gray-400">Loading chart...</div>
+        </div>
+      )}
+      <div ref={chartRef} className={className} style={{ opacity: isLoading ? 0 : 1 }} />
+    </div>
+  );
+};
+
+export const Chart = memo(ChartComponent);

--- a/app/dashboard/DashboardStats.tsx
+++ b/app/dashboard/DashboardStats.tsx
@@ -36,14 +36,14 @@ export function DashboardStats() {
   const [selectedPeriod, setSelectedPeriod] = useState<(typeof TIME_PERIODS)[number]>(TIME_PERIODS[0]);
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       {/* Period Selector */}
       <div className="flex flex-wrap gap-2">
         {TIME_PERIODS.map((period) => (
           <button
             key={period.key}
             onClick={() => setSelectedPeriod(period)}
-            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+            className={`px-3 py-1.5 md:px-4 md:py-2 rounded-lg text-xs md:text-sm font-medium transition-colors ${
               selectedPeriod.key === period.key
                 ? 'bg-blue-600 text-white'
                 : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
@@ -61,9 +61,11 @@ export function DashboardStats() {
       <VisitorTrendsChart period={selectedPeriod.chartPeriod} title={`Visitor Trends - ${selectedPeriod.label}`} />
 
       {/* Top Pages by Period */}
-      <div className="mt-12">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">Most Visited Pages</h2>
-        <div className="space-y-8">
+      <div className="mt-8 md:mt-12">
+        <h2 className="text-xl md:text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4 md:mb-6">
+          Most Visited Pages
+        </h2>
+        <div className="space-y-6 md:space-y-8">
           {TOP_PAGES_PERIODS.map((period) => (
             <StatsPeriod key={period.key} period={period.key} label={period.label} description={period.description} />
           ))}
@@ -101,40 +103,53 @@ function StatsPeriod({ period, label, description }: StatsPeriodProps) {
 
   return (
     <StatsSection title={label} description={description} isLoading={false}>
-      <div className="overflow-x-auto">
-        <table className="w-full">
-          <thead>
-            <tr className="border-b border-gray-200 dark:border-gray-700">
-              <th className="text-left py-3 px-2 text-sm font-semibold text-gray-700 dark:text-gray-300">Rank</th>
-              <th className="text-left py-3 px-2 text-sm font-semibold text-gray-700 dark:text-gray-300">Page</th>
-              <th className="text-right py-3 px-2 text-sm font-semibold text-gray-700 dark:text-gray-300">Visitors</th>
-              <th className="text-right py-3 px-2 text-sm font-semibold text-gray-700 dark:text-gray-300">
-                Page Views
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {data.results.map((stat, index) => (
-              <tr key={stat.page} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors">
-                <td className="py-3 px-2 text-sm text-gray-600 dark:text-gray-400">#{index + 1}</td>
-                <td className="py-3 px-2">
-                  <a
-                    href={stat.page}
-                    className="text-blue-600 dark:text-blue-400 hover:underline text-sm break-all"
-                  >
-                    {stat.page}
-                  </a>
-                </td>
-                <td className="py-3 px-2 text-right text-sm text-gray-900 dark:text-gray-100 font-medium">
-                  {stat.visitors.toLocaleString()}
-                </td>
-                <td className="py-3 px-2 text-right text-sm text-gray-900 dark:text-gray-100 font-medium">
-                  {stat.pageviews.toLocaleString()}
-                </td>
+      <div className="overflow-x-auto -mx-4 md:mx-0">
+        <div className="inline-block min-w-full align-middle">
+          <table className="min-w-full">
+            <thead>
+              <tr className="border-b border-gray-200 dark:border-gray-700">
+                <th className="text-left py-2 md:py-3 px-2 text-xs md:text-sm font-semibold text-gray-700 dark:text-gray-300">
+                  #
+                </th>
+                <th className="text-left py-2 md:py-3 px-2 text-xs md:text-sm font-semibold text-gray-700 dark:text-gray-300">
+                  Page
+                </th>
+                <th className="text-right py-2 md:py-3 px-2 text-xs md:text-sm font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                  Visitors
+                </th>
+                <th className="text-right py-2 md:py-3 px-2 text-xs md:text-sm font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                  Views
+                </th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {data.results.map((stat, index) => (
+                <tr
+                  key={stat.page}
+                  className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors"
+                >
+                  <td className="py-2 md:py-3 px-2 text-xs md:text-sm text-gray-600 dark:text-gray-400">
+                    {index + 1}
+                  </td>
+                  <td className="py-2 md:py-3 px-2">
+                    <a
+                      href={stat.page}
+                      className="text-blue-600 dark:text-blue-400 hover:underline text-xs md:text-sm break-all line-clamp-2 md:line-clamp-none"
+                    >
+                      {stat.page}
+                    </a>
+                  </td>
+                  <td className="py-2 md:py-3 px-2 text-right text-xs md:text-sm text-gray-900 dark:text-gray-100 font-medium whitespace-nowrap">
+                    {stat.visitors.toLocaleString()}
+                  </td>
+                  <td className="py-2 md:py-3 px-2 text-right text-xs md:text-sm text-gray-900 dark:text-gray-100 font-medium whitespace-nowrap">
+                    {stat.pageviews.toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     </StatsSection>
   );

--- a/app/dashboard/DashboardStats.tsx
+++ b/app/dashboard/DashboardStats.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import useSWR from 'swr';
+import { fetcher } from 'lib/fetcher';
+import { StatsSection } from './StatsSection';
+
+type PageStat = {
+  page: string;
+  visitors: number;
+  pageviews: number;
+};
+
+type StatsResponse = {
+  period: string;
+  results: PageStat[];
+  error?: string;
+};
+
+const TIME_PERIODS = [
+  { key: 'all', label: 'All Time', description: 'Most visited pages since site inception' },
+  { key: 'year', label: 'This Year', description: 'Top pages from the last 12 months' },
+  { key: 'month', label: 'This Month', description: 'Most popular pages this month' },
+  { key: 'week', label: 'This Week', description: 'Trending pages in the last 7 days' }
+] as const;
+
+export function DashboardStats() {
+  return (
+    <div className="space-y-8">
+      {TIME_PERIODS.map((period) => (
+        <StatsPeriod key={period.key} period={period.key} label={period.label} description={period.description} />
+      ))}
+    </div>
+  );
+}
+
+type StatsPeriodProps = {
+  period: string;
+  label: string;
+  description: string;
+};
+
+function StatsPeriod({ period, label, description }: StatsPeriodProps) {
+  const { data, error } = useSWR<StatsResponse>(`/api/dashboard-stats?period=${period}&limit=10`, fetcher, {
+    // Revalidate every 5 minutes
+    refreshInterval: 5 * 60 * 1000,
+    // Don't revalidate on focus
+    revalidateOnFocus: false
+  });
+
+  if (error || data?.error) {
+    return (
+      <StatsSection title={label} description={description} isLoading={false}>
+        <p className="text-red-600 dark:text-red-400">Failed to load stats</p>
+      </StatsSection>
+    );
+  }
+
+  if (!data) {
+    return <StatsSection title={label} description={description} isLoading={true} />;
+  }
+
+  return (
+    <StatsSection title={label} description={description} isLoading={false}>
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-gray-200 dark:border-gray-700">
+              <th className="text-left py-3 px-2 text-sm font-semibold text-gray-700 dark:text-gray-300">Rank</th>
+              <th className="text-left py-3 px-2 text-sm font-semibold text-gray-700 dark:text-gray-300">Page</th>
+              <th className="text-right py-3 px-2 text-sm font-semibold text-gray-700 dark:text-gray-300">Visitors</th>
+              <th className="text-right py-3 px-2 text-sm font-semibold text-gray-700 dark:text-gray-300">
+                Page Views
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.results.map((stat, index) => (
+              <tr key={stat.page} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors">
+                <td className="py-3 px-2 text-sm text-gray-600 dark:text-gray-400">#{index + 1}</td>
+                <td className="py-3 px-2">
+                  <a
+                    href={stat.page}
+                    className="text-blue-600 dark:text-blue-400 hover:underline text-sm break-all"
+                  >
+                    {stat.page}
+                  </a>
+                </td>
+                <td className="py-3 px-2 text-right text-sm text-gray-900 dark:text-gray-100 font-medium">
+                  {stat.visitors.toLocaleString()}
+                </td>
+                <td className="py-3 px-2 text-right text-sm text-gray-900 dark:text-gray-100 font-medium">
+                  {stat.pageviews.toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </StatsSection>
+  );
+}

--- a/app/dashboard/DashboardStats.tsx
+++ b/app/dashboard/DashboardStats.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import { useState } from 'react';
 import useSWR from 'swr';
 import { fetcher } from 'lib/fetcher';
 import { StatsSection } from './StatsSection';
+import { AggregateStats } from './AggregateStats';
+import { VisitorTrendsChart } from './VisitorTrendsChart';
 
 type PageStat = {
   page: string;
@@ -17,6 +20,12 @@ type StatsResponse = {
 };
 
 const TIME_PERIODS = [
+  { key: '30d', label: 'Last 30 Days', chartPeriod: '30d' as const },
+  { key: '7d', label: 'Last 7 Days', chartPeriod: '7d' as const },
+  { key: '12mo', label: 'Last 12 Months', chartPeriod: '12mo' as const }
+] as const;
+
+const TOP_PAGES_PERIODS = [
   { key: 'all', label: 'All Time', description: 'Most visited pages since site inception' },
   { key: 'year', label: 'This Year', description: 'Top pages from the last 12 months' },
   { key: 'month', label: 'This Month', description: 'Most popular pages this month' },
@@ -24,11 +33,42 @@ const TIME_PERIODS = [
 ] as const;
 
 export function DashboardStats() {
+  const [selectedPeriod, setSelectedPeriod] = useState<(typeof TIME_PERIODS)[number]>(TIME_PERIODS[0]);
+
   return (
     <div className="space-y-8">
-      {TIME_PERIODS.map((period) => (
-        <StatsPeriod key={period.key} period={period.key} label={period.label} description={period.description} />
-      ))}
+      {/* Period Selector */}
+      <div className="flex flex-wrap gap-2">
+        {TIME_PERIODS.map((period) => (
+          <button
+            key={period.key}
+            onClick={() => setSelectedPeriod(period)}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              selectedPeriod.key === period.key
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+            }`}
+          >
+            {period.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Aggregate Stats Cards */}
+      <AggregateStats period={selectedPeriod.key} />
+
+      {/* Visitor Trends Chart */}
+      <VisitorTrendsChart period={selectedPeriod.chartPeriod} title={`Visitor Trends - ${selectedPeriod.label}`} />
+
+      {/* Top Pages by Period */}
+      <div className="mt-12">
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">Most Visited Pages</h2>
+        <div className="space-y-8">
+          {TOP_PAGES_PERIODS.map((period) => (
+            <StatsPeriod key={period.key} period={period.key} label={period.label} description={period.description} />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/dashboard/StatsCard.tsx
+++ b/app/dashboard/StatsCard.tsx
@@ -11,16 +11,18 @@ type StatsCardProps = {
 
 export function StatsCard({ title, value, subtitle, icon, trend }: StatsCardProps) {
   return (
-    <div className="bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800 p-6 shadow-sm">
+    <div className="border border-dashed border-gray-400 dark:border-none p-4 md:p-6">
       <div className="flex items-start justify-between">
-        <div className="flex-1">
-          <p className="text-sm font-medium text-gray-600 dark:text-gray-400">{title}</p>
-          <p className="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">{value}</p>
-          {subtitle && <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">{subtitle}</p>}
+        <div className="flex-1 min-w-0">
+          <p className="text-xs md:text-sm font-medium text-gray-600 dark:text-gray-400 truncate">{title}</p>
+          <p className="mt-1 md:mt-2 text-2xl md:text-3xl font-bold text-gray-900 dark:text-gray-100 break-words">
+            {value}
+          </p>
+          {subtitle && <p className="mt-0.5 md:mt-1 text-xs md:text-sm text-gray-500 dark:text-gray-500">{subtitle}</p>}
           {trend && (
-            <div className="mt-2 flex items-center gap-1">
+            <div className="mt-1 md:mt-2 flex items-center gap-1">
               <span
-                className={`text-sm font-medium ${trend.isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
+                className={`text-xs md:text-sm font-medium ${trend.isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
               >
                 {trend.isPositive ? '↑' : '↓'} {Math.abs(trend.value)}%
               </span>
@@ -28,7 +30,7 @@ export function StatsCard({ title, value, subtitle, icon, trend }: StatsCardProp
             </div>
           )}
         </div>
-        {icon && <div className="ml-4 text-gray-400 dark:text-gray-600">{icon}</div>}
+        {icon && <div className="ml-2 md:ml-4 text-gray-400 dark:text-gray-600 flex-shrink-0">{icon}</div>}
       </div>
     </div>
   );

--- a/app/dashboard/StatsCard.tsx
+++ b/app/dashboard/StatsCard.tsx
@@ -1,0 +1,35 @@
+type StatsCardProps = {
+  title: string;
+  value: string | number;
+  subtitle?: string;
+  icon?: React.ReactNode;
+  trend?: {
+    value: number;
+    isPositive: boolean;
+  };
+};
+
+export function StatsCard({ title, value, subtitle, icon, trend }: StatsCardProps) {
+  return (
+    <div className="bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800 p-6 shadow-sm">
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <p className="text-sm font-medium text-gray-600 dark:text-gray-400">{title}</p>
+          <p className="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">{value}</p>
+          {subtitle && <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">{subtitle}</p>}
+          {trend && (
+            <div className="mt-2 flex items-center gap-1">
+              <span
+                className={`text-sm font-medium ${trend.isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
+              >
+                {trend.isPositive ? '↑' : '↓'} {Math.abs(trend.value)}%
+              </span>
+              <span className="text-xs text-gray-500 dark:text-gray-500">vs last period</span>
+            </div>
+          )}
+        </div>
+        {icon && <div className="ml-4 text-gray-400 dark:text-gray-600">{icon}</div>}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/StatsSection.tsx
+++ b/app/dashboard/StatsSection.tsx
@@ -1,0 +1,33 @@
+import { ReactNode } from 'react';
+
+type StatsSectionProps = {
+  title: string;
+  description: string;
+  isLoading: boolean;
+  children?: ReactNode;
+};
+
+export function StatsSection({ title, description, isLoading, children }: StatsSectionProps) {
+  return (
+    <section className="bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800 p-6 shadow-sm">
+      <div className="mb-4">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-1">{title}</h2>
+        <p className="text-sm text-gray-600 dark:text-gray-400">{description}</p>
+      </div>
+      {isLoading ? (
+        <div className="space-y-3">
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className="animate-pulse flex space-x-4">
+              <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded w-8"></div>
+              <div className="flex-1 h-4 bg-gray-200 dark:bg-gray-800 rounded"></div>
+              <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded w-20"></div>
+              <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded w-20"></div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        children
+      )}
+    </section>
+  );
+}

--- a/app/dashboard/StatsSection.tsx
+++ b/app/dashboard/StatsSection.tsx
@@ -9,19 +9,19 @@ type StatsSectionProps = {
 
 export function StatsSection({ title, description, isLoading, children }: StatsSectionProps) {
   return (
-    <section className="bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800 p-6 shadow-sm">
-      <div className="mb-4">
-        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-1">{title}</h2>
-        <p className="text-sm text-gray-600 dark:text-gray-400">{description}</p>
+    <section className="border border-dashed border-gray-400 dark:border-none p-4 md:p-6">
+      <div className="mb-3 md:mb-4">
+        <h3 className="text-base md:text-lg font-bold text-gray-900 dark:text-gray-100 mb-1">{title}</h3>
+        <p className="text-xs md:text-sm text-gray-600 dark:text-gray-400">{description}</p>
       </div>
       {isLoading ? (
         <div className="space-y-3">
           {[...Array(5)].map((_, i) => (
-            <div key={i} className="animate-pulse flex space-x-4">
-              <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded w-8"></div>
+            <div key={i} className="animate-pulse flex space-x-2 md:space-x-4">
+              <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded w-6 md:w-8"></div>
               <div className="flex-1 h-4 bg-gray-200 dark:bg-gray-800 rounded"></div>
-              <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded w-20"></div>
-              <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded w-20"></div>
+              <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded w-16 md:w-20"></div>
+              <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded w-16 md:w-20"></div>
             </div>
           ))}
         </div>

--- a/app/dashboard/VisitorTrendsChart.tsx
+++ b/app/dashboard/VisitorTrendsChart.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import useSWR from 'swr';
+import { fetcher } from 'lib/fetcher';
+import { Chart } from './Chart';
+import type { ECBasicOption } from 'echarts/types/dist/shared';
+
+type TimeseriesDataPoint = {
+  date: string;
+  visitors: number;
+  pageviews: number;
+};
+
+type TimeseriesResponse = {
+  period: string;
+  results: TimeseriesDataPoint[];
+  error?: string;
+};
+
+type VisitorTrendsChartProps = {
+  period?: '7d' | '30d' | '6mo' | '12mo';
+  title?: string;
+};
+
+export function VisitorTrendsChart({ period = '30d', title = 'Visitor Trends' }: VisitorTrendsChartProps) {
+  const { data, error } = useSWR<TimeseriesResponse>(
+    `/api/dashboard-stats/timeseries?period=${period}`,
+    fetcher,
+    {
+      refreshInterval: 5 * 60 * 1000,
+      revalidateOnFocus: false
+    }
+  );
+
+  if (error || data?.error) {
+    return (
+      <div className="bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800 p-6 shadow-sm">
+        <p className="text-red-600 dark:text-red-400">Failed to load chart data</p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800 p-6 shadow-sm">
+        <div className="h-[400px] flex items-center justify-center">
+          <div className="text-gray-500 dark:text-gray-400">Loading chart...</div>
+        </div>
+      </div>
+    );
+  }
+
+  const dates = data.results.map((item) => item.date);
+  const visitors = data.results.map((item) => item.visitors);
+  const pageviews = data.results.map((item) => item.pageviews);
+
+  const options: ECBasicOption = {
+    title: {
+      text: title,
+      left: 'left',
+      top: 10
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'cross'
+      }
+    },
+    legend: {
+      data: ['Visitors', 'Page Views'],
+      top: 10,
+      right: 60
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: dates,
+      axisLabel: {
+        rotate: 45,
+        formatter: (value: string) => {
+          // Format date for better readability
+          const date = new Date(value);
+          return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+        }
+      }
+    },
+    yAxis: {
+      type: 'value'
+    },
+    series: [
+      {
+        name: 'Visitors',
+        type: 'line',
+        data: visitors,
+        smooth: true,
+        lineStyle: {
+          width: 3
+        },
+        areaStyle: {
+          opacity: 0.3
+        }
+      },
+      {
+        name: 'Page Views',
+        type: 'line',
+        data: pageviews,
+        smooth: true,
+        lineStyle: {
+          width: 3
+        },
+        areaStyle: {
+          opacity: 0.2
+        }
+      }
+    ]
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800 p-6 shadow-sm">
+      <Chart options={options} className="h-[400px] w-full" />
+    </div>
+  );
+}

--- a/app/dashboard/VisitorTrendsChart.tsx
+++ b/app/dashboard/VisitorTrendsChart.tsx
@@ -34,7 +34,7 @@ export function VisitorTrendsChart({ period = '30d', title = 'Visitor Trends' }:
 
   if (error || data?.error) {
     return (
-      <div className="bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800 p-6 shadow-sm">
+      <div className="w-full overflow-hidden border border-dashed border-gray-400 dark:border-none p-6">
         <p className="text-red-600 dark:text-red-400">Failed to load chart data</p>
       </div>
     );
@@ -42,8 +42,8 @@ export function VisitorTrendsChart({ period = '30d', title = 'Visitor Trends' }:
 
   if (!data) {
     return (
-      <div className="bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800 p-6 shadow-sm">
-        <div className="h-[400px] flex items-center justify-center">
+      <div className="w-full overflow-hidden border border-dashed border-gray-400 dark:border-none">
+        <div className="h-[300px] md:h-[400px] flex items-center justify-center">
           <div className="text-gray-500 dark:text-gray-400">Loading chart...</div>
         </div>
       </div>
@@ -54,11 +54,27 @@ export function VisitorTrendsChart({ period = '30d', title = 'Visitor Trends' }:
   const visitors = data.results.map((item) => item.visitors);
   const pageviews = data.results.map((item) => item.pageviews);
 
+  const currentDate = new Date().toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+
   const options: ECBasicOption = {
+    grid: {
+      top: 100,
+      bottom: 80,
+      left: 15,
+      right: 15
+    },
     title: {
       text: title,
-      left: 'left',
-      top: 10
+      subtext: `Data from Plausible Analytics • www.koenvangilst.nl • ${currentDate}`,
+      subtextStyle: {
+        lineHeight: 18
+      },
+      top: 10,
+      left: 10
     },
     tooltip: {
       trigger: 'axis',
@@ -68,24 +84,29 @@ export function VisitorTrendsChart({ period = '30d', title = 'Visitor Trends' }:
     },
     legend: {
       data: ['Visitors', 'Page Views'],
-      top: 10,
-      right: 60
+      bottom: 10,
+      left: 'center'
     },
     xAxis: {
       type: 'category',
       boundaryGap: false,
       data: dates,
+      splitLine: {
+        show: false
+      },
       axisLabel: {
         rotate: 45,
         formatter: (value: string) => {
-          // Format date for better readability
           const date = new Date(value);
           return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
         }
       }
     },
     yAxis: {
-      type: 'value'
+      type: 'value',
+      splitLine: {
+        show: false
+      }
     },
     series: [
       {
@@ -93,11 +114,44 @@ export function VisitorTrendsChart({ period = '30d', title = 'Visitor Trends' }:
         type: 'line',
         data: visitors,
         smooth: true,
-        lineStyle: {
-          width: 3
+        emphasis: {
+          focus: 'series'
+        },
+        color: {
+          type: 'linear',
+          x: 0,
+          y: 0,
+          x2: 0,
+          y2: 1,
+          colorStops: [
+            {
+              offset: 0,
+              color: '#2196f3'
+            },
+            {
+              offset: 1,
+              color: '#cbf3ff'
+            }
+          ]
         },
         areaStyle: {
-          opacity: 0.3
+          color: {
+            type: 'linear',
+            x: 0,
+            y: 0,
+            x2: 0,
+            y2: 1,
+            colorStops: [
+              {
+                offset: 0,
+                color: '#19c9ff'
+              },
+              {
+                offset: 1,
+                color: '#2196f3'
+              }
+            ]
+          }
         }
       },
       {
@@ -105,19 +159,52 @@ export function VisitorTrendsChart({ period = '30d', title = 'Visitor Trends' }:
         type: 'line',
         data: pageviews,
         smooth: true,
-        lineStyle: {
-          width: 3
+        emphasis: {
+          focus: 'series'
+        },
+        color: {
+          type: 'linear',
+          x: 0,
+          y: 0,
+          x2: 0,
+          y2: 1,
+          colorStops: [
+            {
+              offset: 0,
+              color: '#64b5f6'
+            },
+            {
+              offset: 1,
+              color: '#e3f2fd'
+            }
+          ]
         },
         areaStyle: {
-          opacity: 0.2
+          color: {
+            type: 'linear',
+            x: 0,
+            y: 0,
+            x2: 0,
+            y2: 1,
+            colorStops: [
+              {
+                offset: 0,
+                color: '#90caf9'
+              },
+              {
+                offset: 1,
+                color: '#64b5f6'
+              }
+            ]
+          }
         }
       }
     ]
   };
 
   return (
-    <div className="bg-white dark:bg-gray-950 rounded-lg border border-gray-200 dark:border-gray-800 p-6 shadow-sm">
-      <Chart options={options} className="h-[400px] w-full" />
+    <div className="w-full overflow-hidden border border-dashed border-gray-400 dark:border-none">
+      <Chart options={options} className="h-[300px] md:h-[400px] w-full" />
     </div>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,23 @@
+import { Metadata } from 'next';
+import { Main } from 'components/layout/Main';
+import { Heading } from 'components/content/Heading';
+import { DashboardStats } from './DashboardStats';
+
+export const metadata: Metadata = {
+  title: 'Dashboard - Koen van Gilst',
+  description: 'Analytics dashboard showing the most visited pages'
+};
+
+export default function DashboardPage() {
+  return (
+    <Main>
+      <div className="mb-8">
+        <Heading level={1}>Dashboard</Heading>
+        <p className="text-gray-600 dark:text-gray-400 mt-2">
+          Overview of the most visited pages across different time periods
+        </p>
+      </div>
+      <DashboardStats />
+    </Main>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,23 +1,22 @@
 import { Metadata } from 'next';
-import { Main } from 'components/layout/Main';
-import { Heading } from 'components/content/Heading';
 import { DashboardStats } from './DashboardStats';
 
 export const metadata: Metadata = {
   title: 'Dashboard - Koen van Gilst',
-  description: 'Analytics dashboard showing the most visited pages'
+  description: 'Analytics dashboard showing visitor statistics and most visited pages'
 };
 
 export default function DashboardPage() {
   return (
-    <Main>
-      <div className="mb-8">
-        <Heading level={1}>Dashboard</Heading>
-        <p className="text-gray-600 dark:text-gray-400 mt-2">
-          Overview of the most visited pages across different time periods
+    <div className="mb-10 min-h-screen w-full p-4 md:px-8">
+      <div className="prose dark:prose-invert mb-8">
+        <h1>Analytics Dashboard</h1>
+        <p>
+          Overview of visitor statistics and the most visited pages across different time periods. Data is collected
+          via Plausible Analytics, a privacy-friendly analytics platform.
         </p>
       </div>
       <DashboardStats />
-    </Main>
+    </div>
   );
 }

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -12,7 +12,8 @@ import { cx } from 'lib/clsx';
 const navItems = [
   { href: '/', label: 'About' },
   { href: '/lab', label: 'Lab' },
-  { href: '/photography', label: 'Photography' }
+  { href: '/photography', label: 'Photography' },
+  { href: '/dashboard', label: 'Dashboard' }
 ];
 
 export function Header() {

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -11,7 +11,8 @@ import { cx } from 'lib/clsx';
 const navItems = [
   { href: '/', label: 'About' },
   { href: '/lab', label: 'Lab' },
-  { href: '/photography', label: 'Photography' }
+  { href: '/photography', label: 'Photography' },
+  { href: '/dashboard', label: 'Dashboard' }
 ];
 
 export function Sidebar() {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Creates a new /dashboard page that displays the most visited pages across different time periods (all time, this year, this month, this week). Includes:
- New API endpoint at /api/dashboard-stats that fetches breakdown data from Plausible Analytics
- Dashboard page component with responsive table layout
- Stats sections with loading states and dark mode support
- Follows existing site design patterns with Tailwind CSS