### PR TITLE
Fix "Edit on GitHub" link returning 404

### DIFF
--- a/components/content/MarkdownLayout.tsx
+++ b/components/content/MarkdownLayout.tsx
@@ -81,5 +81,6 @@ export async function MarkdownLayout({
 }
 
 function getEditUrl(path: string) {
-  return `https://github.com/vnglst/koenvangilst.nl/edit/main/content${path}.mdx`;
+  const slug = path.split('/').pop();
+  return `https://github.com/vnglst/koenvangilst.nl/edit/main/content/${slug}.mdx`;
 }


### PR DESCRIPTION
The path prop passed to MarkdownLayout is `/lab/<slug>`, so getEditUrl
was generating `.../content/lab/<slug>.mdx`. The actual files live at
`content/<slug>.mdx` (no `/lab/` segment). Extract just the slug from
the path before building the GitHub edit URL.

https://claude.ai/code/session_01NV18Pen4Upijnnzi2KYfdb