### PR TITLE
Simplify layout with flexbox sticky footer

### DIFF
--- a/src/components/layout/Container.tsx
+++ b/src/components/layout/Container.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import type { PropsWithChildren } from 'react';
 
+import { cx } from '#/lib/clsx';
 import { Footer } from './Footer';
 import { Header } from './Header';
 import { Main } from './Main';
@@ -18,11 +19,13 @@ export function Container({ children, footer = true, wide = false }: PropsWithCh
       <Header />
 
       {/* Desktop layout with sidebar */}
-      <div className="mx-4 mt-20 mb-40 flex max-w-4xl flex-col md:mt-20 md:flex-row lg:mx-auto lg:mt-32 lg:px-6">
+      <div className="mx-4 mt-20 flex max-w-4xl flex-1 flex-col md:mt-20 md:flex-row lg:mx-auto lg:mt-32 lg:px-6">
         <Sidebar />
         <Main>
           <Suspense>
-            <div className={wide ? 'w-full lg:max-w-[calc(100vw-200px-3rem)] lg:min-w-[600px]' : 'w-full md:w-9/12'}>
+            <div
+              className={cx('w-full flex-1', wide ? 'lg:max-w-[calc(100vw-200px-3rem)] lg:min-w-[600px]' : 'md:w-9/12')}
+            >
               {children}
             </div>
             {footer && <Footer />}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -131,7 +131,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             `
           }}
         />
-        {children}
+        <div className="flex min-h-screen flex-col">{children}</div>
         <Tracking />
         {DevTools && (
           <Suspense fallback={null}>


### PR DESCRIPTION
This PR simplifies the page layout by replacing the fixed bottom margin approach with a proper flexbox-based sticky footer pattern.

### Changes

- **Root layout (`__root.tsx`)**: Wraps `{children}` in a flex column with `min-h-screen` to ensure the page wrapper always fills at least the viewport height.
- **Container (`Container.tsx`)**:
  - Replaces the hardcoded `mb-40` on the outer div with `flex-1`, allowing the container to grow and fill available vertical space.
  - Adds `flex-1` to the inner content div so it expands within `<Main>` and pushes `<Footer>` to the bottom.
  - Uses the project's `cx()` utility for className composition instead of a template literal.

### Verification

- `npm run type-check`
- `npm run lint`
- `npm run test` (Vitest)
- `npm run test:e2e` (Playwright)