### PR TITLE
Add navigation progress bar and slow-network e2e test

### DIFF
--- a/e2e/slow-network.spec.ts
+++ b/e2e/slow-network.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Simulates a bad mobile connection and verifies that:
+ * 1. A navigation progress indicator is visible while a page transition is pending.
+ * 2. The destination page eventually renders correctly.
+ *
+ * Uses Playwright's route interception to reliably delay server function
+ * responses (/_serverFn/*) — CDP throttling does not affect loopback connections.
+ */
+test.describe('slow network navigation', () => {
+  test('shows a loading indicator during page transition on slow network', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { level: 1, name: 'Koen van Gilst' })).toBeVisible();
+
+    // Wait for TanStack Router to finish hydrating on the client.
+    // The heading visible only means SSR HTML is rendered; React hydration
+    // and router initialization happen shortly after.
+    await page.waitForFunction(() => typeof (window as any).__TSR_ROUTER__ !== 'undefined');
+
+    // Move mouse away from nav links to prevent hover-based preloading before
+    // we set up the delay interceptor.
+    await page.mouse.move(0, 0);
+
+    // Intercept server-function requests and add a 1.5 s delay to simulate a
+    // bad mobile connection. /_serverFn/* is the TanStack Start server fn endpoint.
+    await page.route('**/_serverFn/**', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      await route.continue();
+    });
+
+    // Trigger navigation via a programmatic JS click to avoid Playwright's
+    // mouse simulation dispatching mouseover/mouseenter events that would
+    // trigger TanStack Router's intent-based preloading before the click fires.
+    await page
+      .locator('a[href="/lab"]')
+      .first()
+      .evaluate((el: HTMLAnchorElement) => el.click());
+
+    // The progress bar should appear before the page finishes loading.
+    const progressBar = page.locator('[role="progressbar"]');
+    await expect(progressBar).toBeVisible({ timeout: 3000 });
+
+    // Destination page should load successfully after the delay.
+    await expect(page).toHaveURL(/\/lab/, { timeout: 10_000 });
+    await expect(page.getByRole('heading', { level: 1, name: /articles & experiments/i })).toBeVisible({
+      timeout: 10_000
+    });
+
+    // Progress bar should be gone after navigation completes.
+    await expect(page.locator('[role="progressbar"]')).not.toBeVisible({ timeout: 5000 });
+  });
+});

--- a/src/components/NavigationProgress.tsx
+++ b/src/components/NavigationProgress.tsx
@@ -1,0 +1,74 @@
+import { useRouter } from '@tanstack/react-router';
+import { useEffect, useRef } from 'react';
+
+/**
+ * Thin top-of-page progress bar that appears during route transitions.
+ * Gives users visual feedback on slow connections so they know navigation
+ * is in progress and the page hasn't frozen.
+ *
+ * Uses router events (onBeforeNavigate / onResolved) and direct DOM manipulation
+ * to guarantee immediate visibility — React state updates inside startTransition
+ * may be deferred until the transition completes, making the bar invisible.
+ */
+export function NavigationProgress() {
+  const router = useRouter();
+  const barRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const bar = barRef.current;
+    if (!bar) return;
+
+    const show = () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      bar.style.display = 'block';
+      bar.style.transition = 'none';
+      bar.style.width = '0%';
+      bar.style.opacity = '1';
+      rafRef.current = requestAnimationFrame(() => {
+        bar.style.transition = 'width 10s cubic-bezier(0.1, 0.05, 0, 1)';
+        bar.style.width = '70%';
+      });
+    };
+
+    const hide = () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      bar.style.transition = 'width 200ms ease-out';
+      bar.style.width = '100%';
+      timerRef.current = setTimeout(() => {
+        bar.style.transition = 'opacity 200ms ease-out';
+        bar.style.opacity = '0';
+        timerRef.current = setTimeout(() => {
+          bar.style.display = 'none';
+          bar.style.width = '0%';
+          bar.style.opacity = '1';
+          bar.style.transition = 'none';
+        }, 200);
+      }, 500);
+    };
+
+    const unsubscribeStart = router.subscribe('onBeforeNavigate', show);
+    const unsubscribeEnd = router.subscribe('onResolved', hide);
+
+    return () => {
+      unsubscribeStart();
+      unsubscribeEnd();
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [router]);
+
+  return (
+    <div
+      ref={barRef}
+      role="progressbar"
+      aria-label="Page loading"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      className="bg-primary fixed top-0 left-0 z-[200] h-[3px]"
+      style={{ display: 'none', width: '0%' }}
+    />
+  );
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import appCss from '../styles.css?url';
 
 import type { QueryClient } from '@tanstack/react-query';
 import { Tracking } from '#/components/Tracking';
+import { NavigationProgress } from '#/components/NavigationProgress';
 import { Container } from '#/components/layout/Container';
 import { Prose } from '#/components/content/Prose';
 import { Heading } from '#/components/content/Heading';
@@ -113,6 +114,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body className="bg-slate-50 text-gray-800 antialiased dark:bg-slate-950 dark:text-gray-100">
+        <NavigationProgress />
         {/* Skip to main content for keyboard/screen reader users */}
         <a
           href="#content"


### PR DESCRIPTION
## Summary

Improves the page transition experience on slow/mobile connections by showing a thin progress bar at the top of the page during navigation.

## Changes

- **`src/components/NavigationProgress.tsx`** — New component that subscribes to TanStack Router's `onBeforeNavigate` / `onResolved` events and animates a `role="progressbar"` bar via direct DOM manipulation (bypasses React re-renders for smoother animation).
- **`src/routes/__root.tsx`** — Mounts `<NavigationProgress />` as the first child of `<body>`.
- **`e2e/slow-network.spec.ts`** — E2e test that intercepts `/_serverFn/*` requests with a 1.5 s delay to simulate a bad mobile connection, then asserts the progress bar appears during the transition and disappears once the page resolves.