### PR TITLE
feat: default to dark mode, remove system preference detection

### DIFF
--- a/src/components/theme/ThemeToggleText.tsx
+++ b/src/components/theme/ThemeToggleText.tsx
@@ -4,8 +4,6 @@ import { Icon } from '#/components/ui/Icon';
 
 import { Theme, useTheme } from './theme.store';
 
-const PREFERS_DARK = '(prefers-color-scheme: dark)';
-
 export function ThemeToggleText() {
   const theme = useTheme((state) => state.theme);
   const setTheme = useTheme((state) => state.setTheme);
@@ -14,24 +12,6 @@ export function ThemeToggleText() {
   useEffect(() => {
     setMounted(true);
   }, []);
-
-  useEffect(() => {
-    const handleThemeChange = (e: MediaQueryListEvent) => {
-      if (e.matches) {
-        document.documentElement.classList.add('dark');
-        setTheme(Theme.Dark);
-      } else {
-        document.documentElement.classList.remove('dark');
-        setTheme(Theme.Light);
-      }
-    };
-
-    window.matchMedia(PREFERS_DARK).addEventListener('change', handleThemeChange);
-
-    return () => {
-      window.matchMedia(PREFERS_DARK).removeEventListener('change', handleThemeChange);
-    };
-  }, [setTheme]);
 
   function handleClick() {
     document.documentElement.classList.toggle('dark');

--- a/src/components/theme/theme.store.ts
+++ b/src/components/theme/theme.store.ts
@@ -11,7 +11,7 @@ type Store = {
 };
 
 const getInitialTheme = (): Theme => {
-  if (typeof window === 'undefined') return Theme.Light;
+  if (typeof window === 'undefined') return Theme.Dark;
   const darkClass = document.documentElement.classList.contains('dark');
   return darkClass ? Theme.Dark : Theme.Light;
 };

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -122,13 +122,12 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         >
           Skip to main content
         </a>
-        {/* Inline theme detection to prevent FOUC */}
+        {/* Inline theme detection to prevent FOUC — defaults to dark */}
         <script
           dangerouslySetInnerHTML={{
             __html: `
-              const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
               const preferredTheme = localStorage.getItem('theme');
-              if (preferredTheme === 'dark' || (!preferredTheme && systemDark)) {
+              if (preferredTheme !== 'light') {
                 document.documentElement.classList.add('dark');
               }
 


### PR DESCRIPTION
## Summary

Changes the website to display in dark mode by default instead of falling back to system preference. Users can still switch themes, and their choice is persisted in localStorage.

## Changes

1. **FOUC prevention script** (): Simplified to always add the `dark` class unless the user has explicitly chosen `light` in localStorage. Removed system preference check.

2. **ThemeToggleText** (): Removed the `prefers-color-scheme` change listener that would auto-switch themes based on OS changes. The toggle now only responds to manual user actions.

3. **Theme store** (): Changed SSR default from `Theme.Light` to `Theme.Dark`.

## Verification

- `npm run type-check` — passed
- `npm run lint` — passed (no new warnings)
- `npm run test` — 33/33 tests passed