### PR TITLE
Show loading skeleton on photos page when data not available

### DIFF
--- a/e2e/photography.spec.ts
+++ b/e2e/photography.spec.ts
@@ -1,6 +1,34 @@
 import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DATA_FILE = path.join(process.cwd(), 'public/static/photos-data.json');
+const DATA_FILE_BACKUP = path.join(process.cwd(), 'public/static/photos-data.json.bak');
 
 test.describe('photography', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('shows loading skeleton when photos are not yet processed', async ({ page }) => {
+    try {
+      fs.renameSync(DATA_FILE, DATA_FILE_BACKUP);
+    } catch {
+      // File may already be missing
+    }
+
+    try {
+      await page.goto('/photography');
+
+      await expect(page).toHaveTitle(/Photography/i);
+      await expect(page.locator('.animate-pulse')).toHaveCount(6);
+    } finally {
+      try {
+        fs.renameSync(DATA_FILE_BACKUP, DATA_FILE);
+      } catch {
+        // Restore failed, file may not have existed
+      }
+    }
+  });
+
   test('photo gallery can render its fullscreen viewer state', async ({ page }) => {
     await page.goto('/photography?photo=0-gallery');
 

--- a/src/routes/photography/_components/PhotoGallery.tsx
+++ b/src/routes/photography/_components/PhotoGallery.tsx
@@ -163,14 +163,31 @@ function FullScreenGallery({ photos, startIndex }: { photos: PhotoType[]; startI
   );
 }
 
+function PhotoGallerySkeleton() {
+  return (
+    <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div
+          key={i}
+          className="aspect-square animate-pulse rounded-lg bg-gray-200 dark:bg-gray-800"
+        />
+      ))}
+    </div>
+  );
+}
+
 export function PhotoGallery({ photos }: PhotoGalleryProps) {
   const navigate = useNavigate();
   const search = useSearch({ from: '/photography/' });
   const photoParam = (search as Record<string, string | undefined>).photo;
   const selectedIndex = photoParam ? parseInt(photoParam, 10) : 0;
 
-  if (photoParam !== undefined) {
+  if (photoParam !== undefined && photos.length > 0) {
     return <FullScreenGallery photos={photos} startIndex={selectedIndex} />;
+  }
+
+  if (photos.length === 0) {
+    return <PhotoGallerySkeleton />;
   }
 
   return (


### PR DESCRIPTION
Adds an animated loading skeleton placeholder on the photography page when photos-data.json is not yet generated (e.g. during image processing at container startup).

**Changes:**
- PhotoGallery.tsx: Added PhotoGallerySkeleton component with animate-pulse placeholder squares matching the responsive grid layout (1/2/3 columns). Renders when photos array is empty.
- photography.spec.ts: Added e2e test that temporarily removes photos-data.json and verifies the skeleton renders (6 animated placeholder elements). Tests run serially.

All 29 e2e tests pass.