### PR TITLE
fix: prevent sidebar layout shift during MDX loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,42 @@ Use the Playwright suite as a required regression check when a change affects mu
 - Transform tasks into verifiable goals.
 - Loop until verified.
 
+### Preventing Layout Shifts
+
+Layout shifts (CLS — Cumulative Layout Shift) create a jarring user experience where page elements visibly jump during loading. Always follow these rules:
+
+**1. Suspense fallbacks must preserve layout structure.**
+When a `<Suspense>` boundary wraps a component that includes layout chrome (sidebar, header, container divs), the fallback skeleton MUST include the same layout structure. Never let a loading fallback render centered full-width content if the final state includes a sidebar that shifts it to the side.
+
+```tsx
+// BAD — skeleton is centered, final layout has sidebar → layout shift
+<Suspense fallback={<div className="mx-auto max-w-prose">Loading...</div>}>
+  <PageLayout>  {/* includes <Sidebar /> + main content */}
+    <Content />
+  </PageLayout>
+</Suspense>
+
+// GOOD — skeleton preserves the same chrome
+<Suspense fallback={<PageLayout><div className="mx-auto max-w-prose animate-pulse">Loading...</div></PageLayout>}>
+  <PageLayout>
+    <Content />
+  </PageLayout>
+</Suspense>
+```
+
+**2. Reserve space for async content.**
+Give loading skeletons the same dimensions (width, height, margins) as the final content they replace. Use `min-h`, `min-w`, or explicit sizing to prevent the page from collapsing while content loads.
+
+**3. Always verify with throttled network.**
+Open DevTools → Network tab → set throttling to "Slow 3G", then hard-reload the page. Watch for any visible jumps in the sidebar, header, or content area. Fix every shift you see before considering the work done.
+
+**4. This project's anti-shift measures (do not remove):**
+- `html { overflow-y: scroll }` in `global.css` — forces a permanent scrollbar so pages never shift horizontally when content height changes
+- Inline theme script in `__root.tsx` — applies `dark` class before paint to prevent FOUC
+- Font preloads in `HeadContent` — prevents FOUT (Flash of Unstyled Text)
+
+
+
 ### Close the Feedback Loop First
 
 - Before solving, build a way to observe.

--- a/e2e/layout-shift.spec.ts
+++ b/e2e/layout-shift.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('layout shift on blog post', () => {
+  test('sidebar position does not shift while MDX Suspense resolves', async ({ page }) => {
+    // Simulate slow MDX chunk loading to trigger the Suspense boundary.
+    // The PostPage Suspense should show a Container-wrapped skeleton,
+    // preserving the sidebar position throughout.
+
+    let releaseMdx: () => void;
+    const mdxReady = new Promise<void>((r) => { releaseMdx = r; });
+
+    await page.route('**/assets/_slug-*.js', async (route) => {
+      await mdxReady;
+      await route.continue();
+    });
+
+    await page.goto('/lab/ai-and-the-future-of-engineering', { waitUntil: 'domcontentloaded' });
+
+    const aside = page.locator('aside');
+    await expect(aside).toBeAttached({ timeout: 10_000 });
+    await page.waitForTimeout(500);
+
+    // Position while Suspense is pending (skeleton showing)
+    const loadingBox = await aside.boundingBox();
+    const loadingX = loadingBox?.x ?? -1;
+    console.log(`Loading (skeleton) aside x: ${loadingX}`);
+
+    // Release MDX chunks
+    releaseMdx!();
+
+    // Wait for article content to appear
+    await expect(page.getByRole('heading', { level: 1, name: /Growing/i })).toBeVisible({
+      timeout: 15_000
+    });
+    await page.waitForTimeout(500);
+
+    const resolvedBox = await aside.boundingBox();
+    const resolvedX = resolvedBox?.x ?? -1;
+    console.log(`Resolved aside x: ${resolvedX}`);
+
+    // Sidebar x must be stable (tolerance of 2px)
+    expect(resolvedX, `sidebar shifted: ${loadingX} → ${resolvedX}`).toBeCloseTo(loadingX, 0);
+  });
+
+  test('sidebar x does not change on direct navigation without throttling', async ({ page }) => {
+    // Plain navigation — verify no shift in normal conditions
+    await page.goto('/lab/ai-and-the-future-of-engineering');
+
+    const aside = page.locator('aside');
+    await expect(aside).toBeAttached({ timeout: 10_000 });
+
+    const box1 = await aside.boundingBox();
+    const x1 = box1?.x ?? -1;
+
+    // Wait for full hydration
+    await expect(page.getByRole('heading', { level: 1, name: /Growing/i })).toBeVisible({
+      timeout: 10_000
+    });
+    await page.waitForTimeout(500);
+
+    const box2 = await aside.boundingBox();
+    const x2 = box2?.x ?? -1;
+
+    console.log(`Initial x: ${x1}, final x: ${x2}`);
+    expect(x2).toBeCloseTo(x1, 0);
+  });
+});

--- a/src/components/layout/Container.tsx
+++ b/src/components/layout/Container.tsx
@@ -19,7 +19,7 @@ export function Container({ children, footer = true, wide = false }: PropsWithCh
       <Header />
 
       {/* Desktop layout with sidebar */}
-      <div className="mx-4 mt-20 flex max-w-4xl flex-1 flex-col md:mt-20 md:flex-row lg:mx-auto lg:mt-32 lg:px-6">
+      <div className="mx-4 mt-20 flex max-w-4xl flex-1 flex-col md:mx-auto md:mt-20 md:flex-row lg:mt-32 lg:px-6">
         <Sidebar />
         <Main>
           <Suspense>

--- a/src/components/layout/Container.tsx
+++ b/src/components/layout/Container.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { cx } from '#/lib/clsx';
@@ -15,21 +14,17 @@ type ContainerProps = {
 export function Container({ children, footer = true, wide = false }: PropsWithChildren<ContainerProps>) {
   return (
     <>
-      {/* Mobile header only */}
       <Header />
 
-      {/* Desktop layout with sidebar */}
       <div className="mx-4 mt-20 flex max-w-4xl flex-1 flex-col md:mx-auto md:mt-20 md:flex-row lg:mt-32 lg:px-6">
         <Sidebar />
         <Main>
-          <Suspense>
-            <div
-              className={cx('w-full flex-1', wide ? 'lg:max-w-[calc(100vw-200px-3rem)] lg:min-w-[600px]' : 'md:w-9/12')}
-            >
-              {children}
-            </div>
-            {footer && <Footer />}
-          </Suspense>
+          <div
+            className={cx('w-full flex-1', wide ? 'lg:max-w-[calc(100vw-200px-3rem)] lg:min-w-[600px]' : 'md:w-9/12')}
+          >
+            {children}
+          </div>
+          {footer && <Footer />}
         </Main>
       </div>
     </>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -8,270 +8,270 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root';
-import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml';
-import { Route as OgRouteImport } from './routes/og';
-import { Route as LlmContextRouteImport } from './routes/llm-context';
-import { Route as HealthRouteImport } from './routes/health';
-import { Route as FeedDotxmlRouteImport } from './routes/feed[.]xml';
-import { Route as AboutRouteImport } from './routes/about';
-import { Route as IndexRouteImport } from './routes/index';
-import { Route as SnippetsIndexRouteImport } from './routes/snippets/index';
-import { Route as ProjectsIndexRouteImport } from './routes/projects/index';
-import { Route as PortfolioIndexRouteImport } from './routes/portfolio/index';
-import { Route as PhotographyIndexRouteImport } from './routes/photography/index';
-import { Route as LabsIndexRouteImport } from './routes/labs/index';
-import { Route as LabIndexRouteImport } from './routes/lab/index';
-import { Route as ClientsIndexRouteImport } from './routes/clients/index';
-import { Route as BlogIndexRouteImport } from './routes/blog/index';
-import { Route as TagSlugRouteImport } from './routes/tag/$slug';
-import { Route as SnippetsSplatRouteImport } from './routes/snippets/$';
-import { Route as ProjectsSplatRouteImport } from './routes/projects/$';
-import { Route as PortfolioSplatRouteImport } from './routes/portfolio/$';
-import { Route as LabsSplatRouteImport } from './routes/labs/$';
-import { Route as LabSlugRouteImport } from './routes/lab/$slug';
-import { Route as ClientsSplatRouteImport } from './routes/clients/$';
-import { Route as BlogSplatRouteImport } from './routes/blog/$';
-import { Route as LabPrognosis2100IndexRouteImport } from './routes/lab/prognosis-2100/index';
-import { Route as LabOnsLandIndexRouteImport } from './routes/lab/ons-land/index';
-import { Route as LabGenArtGalleryIndexRouteImport } from './routes/lab/gen-art-gallery/index';
-import { Route as LabCo2IndexRouteImport } from './routes/lab/co2/index';
-import { Route as PhotographyPhotoSplatRouteImport } from './routes/photography/photo/$';
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
+import { Route as OgRouteImport } from './routes/og'
+import { Route as LlmContextRouteImport } from './routes/llm-context'
+import { Route as HealthRouteImport } from './routes/health'
+import { Route as FeedDotxmlRouteImport } from './routes/feed[.]xml'
+import { Route as AboutRouteImport } from './routes/about'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as SnippetsIndexRouteImport } from './routes/snippets/index'
+import { Route as ProjectsIndexRouteImport } from './routes/projects/index'
+import { Route as PortfolioIndexRouteImport } from './routes/portfolio/index'
+import { Route as PhotographyIndexRouteImport } from './routes/photography/index'
+import { Route as LabsIndexRouteImport } from './routes/labs/index'
+import { Route as LabIndexRouteImport } from './routes/lab/index'
+import { Route as ClientsIndexRouteImport } from './routes/clients/index'
+import { Route as BlogIndexRouteImport } from './routes/blog/index'
+import { Route as TagSlugRouteImport } from './routes/tag/$slug'
+import { Route as SnippetsSplatRouteImport } from './routes/snippets/$'
+import { Route as ProjectsSplatRouteImport } from './routes/projects/$'
+import { Route as PortfolioSplatRouteImport } from './routes/portfolio/$'
+import { Route as LabsSplatRouteImport } from './routes/labs/$'
+import { Route as LabSlugRouteImport } from './routes/lab/$slug'
+import { Route as ClientsSplatRouteImport } from './routes/clients/$'
+import { Route as BlogSplatRouteImport } from './routes/blog/$'
+import { Route as LabPrognosis2100IndexRouteImport } from './routes/lab/prognosis-2100/index'
+import { Route as LabOnsLandIndexRouteImport } from './routes/lab/ons-land/index'
+import { Route as LabGenArtGalleryIndexRouteImport } from './routes/lab/gen-art-gallery/index'
+import { Route as LabCo2IndexRouteImport } from './routes/lab/co2/index'
+import { Route as PhotographyPhotoSplatRouteImport } from './routes/photography/photo/$'
 
 const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
   id: '/sitemap.xml',
   path: '/sitemap.xml',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const OgRoute = OgRouteImport.update({
   id: '/og',
   path: '/og',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LlmContextRoute = LlmContextRouteImport.update({
   id: '/llm-context',
   path: '/llm-context',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const HealthRoute = HealthRouteImport.update({
   id: '/health',
   path: '/health',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const FeedDotxmlRoute = FeedDotxmlRouteImport.update({
   id: '/feed.xml',
   path: '/feed.xml',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AboutRoute = AboutRouteImport.update({
   id: '/about',
   path: '/about',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SnippetsIndexRoute = SnippetsIndexRouteImport.update({
   id: '/snippets/',
   path: '/snippets/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ProjectsIndexRoute = ProjectsIndexRouteImport.update({
   id: '/projects/',
   path: '/projects/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PortfolioIndexRoute = PortfolioIndexRouteImport.update({
   id: '/portfolio/',
   path: '/portfolio/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PhotographyIndexRoute = PhotographyIndexRouteImport.update({
   id: '/photography/',
   path: '/photography/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LabsIndexRoute = LabsIndexRouteImport.update({
   id: '/labs/',
   path: '/labs/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LabIndexRoute = LabIndexRouteImport.update({
   id: '/lab/',
   path: '/lab/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ClientsIndexRoute = ClientsIndexRouteImport.update({
   id: '/clients/',
   path: '/clients/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BlogIndexRoute = BlogIndexRouteImport.update({
   id: '/blog/',
   path: '/blog/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const TagSlugRoute = TagSlugRouteImport.update({
   id: '/tag/$slug',
   path: '/tag/$slug',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SnippetsSplatRoute = SnippetsSplatRouteImport.update({
   id: '/snippets/$',
   path: '/snippets/$',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ProjectsSplatRoute = ProjectsSplatRouteImport.update({
   id: '/projects/$',
   path: '/projects/$',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PortfolioSplatRoute = PortfolioSplatRouteImport.update({
   id: '/portfolio/$',
   path: '/portfolio/$',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LabsSplatRoute = LabsSplatRouteImport.update({
   id: '/labs/$',
   path: '/labs/$',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LabSlugRoute = LabSlugRouteImport.update({
   id: '/lab/$slug',
   path: '/lab/$slug',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ClientsSplatRoute = ClientsSplatRouteImport.update({
   id: '/clients/$',
   path: '/clients/$',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BlogSplatRoute = BlogSplatRouteImport.update({
   id: '/blog/$',
   path: '/blog/$',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LabPrognosis2100IndexRoute = LabPrognosis2100IndexRouteImport.update({
   id: '/lab/prognosis-2100/',
   path: '/lab/prognosis-2100/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LabOnsLandIndexRoute = LabOnsLandIndexRouteImport.update({
   id: '/lab/ons-land/',
   path: '/lab/ons-land/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LabGenArtGalleryIndexRoute = LabGenArtGalleryIndexRouteImport.update({
   id: '/lab/gen-art-gallery/',
   path: '/lab/gen-art-gallery/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LabCo2IndexRoute = LabCo2IndexRouteImport.update({
   id: '/lab/co2/',
   path: '/lab/co2/',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PhotographyPhotoSplatRoute = PhotographyPhotoSplatRouteImport.update({
   id: '/photography/photo/$',
   path: '/photography/photo/$',
-  getParentRoute: () => rootRouteImport
-} as any);
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute;
-  '/about': typeof AboutRoute;
-  '/feed.xml': typeof FeedDotxmlRoute;
-  '/health': typeof HealthRoute;
-  '/llm-context': typeof LlmContextRoute;
-  '/og': typeof OgRoute;
-  '/sitemap.xml': typeof SitemapDotxmlRoute;
-  '/blog/$': typeof BlogSplatRoute;
-  '/clients/$': typeof ClientsSplatRoute;
-  '/lab/$slug': typeof LabSlugRoute;
-  '/labs/$': typeof LabsSplatRoute;
-  '/portfolio/$': typeof PortfolioSplatRoute;
-  '/projects/$': typeof ProjectsSplatRoute;
-  '/snippets/$': typeof SnippetsSplatRoute;
-  '/tag/$slug': typeof TagSlugRoute;
-  '/blog/': typeof BlogIndexRoute;
-  '/clients/': typeof ClientsIndexRoute;
-  '/lab/': typeof LabIndexRoute;
-  '/labs/': typeof LabsIndexRoute;
-  '/photography/': typeof PhotographyIndexRoute;
-  '/portfolio/': typeof PortfolioIndexRoute;
-  '/projects/': typeof ProjectsIndexRoute;
-  '/snippets/': typeof SnippetsIndexRoute;
-  '/photography/photo/$': typeof PhotographyPhotoSplatRoute;
-  '/lab/co2/': typeof LabCo2IndexRoute;
-  '/lab/gen-art-gallery/': typeof LabGenArtGalleryIndexRoute;
-  '/lab/ons-land/': typeof LabOnsLandIndexRoute;
-  '/lab/prognosis-2100/': typeof LabPrognosis2100IndexRoute;
+  '/': typeof IndexRoute
+  '/about': typeof AboutRoute
+  '/feed.xml': typeof FeedDotxmlRoute
+  '/health': typeof HealthRoute
+  '/llm-context': typeof LlmContextRoute
+  '/og': typeof OgRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/blog/$': typeof BlogSplatRoute
+  '/clients/$': typeof ClientsSplatRoute
+  '/lab/$slug': typeof LabSlugRoute
+  '/labs/$': typeof LabsSplatRoute
+  '/portfolio/$': typeof PortfolioSplatRoute
+  '/projects/$': typeof ProjectsSplatRoute
+  '/snippets/$': typeof SnippetsSplatRoute
+  '/tag/$slug': typeof TagSlugRoute
+  '/blog/': typeof BlogIndexRoute
+  '/clients/': typeof ClientsIndexRoute
+  '/lab/': typeof LabIndexRoute
+  '/labs/': typeof LabsIndexRoute
+  '/photography/': typeof PhotographyIndexRoute
+  '/portfolio/': typeof PortfolioIndexRoute
+  '/projects/': typeof ProjectsIndexRoute
+  '/snippets/': typeof SnippetsIndexRoute
+  '/photography/photo/$': typeof PhotographyPhotoSplatRoute
+  '/lab/co2/': typeof LabCo2IndexRoute
+  '/lab/gen-art-gallery/': typeof LabGenArtGalleryIndexRoute
+  '/lab/ons-land/': typeof LabOnsLandIndexRoute
+  '/lab/prognosis-2100/': typeof LabPrognosis2100IndexRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute;
-  '/about': typeof AboutRoute;
-  '/feed.xml': typeof FeedDotxmlRoute;
-  '/health': typeof HealthRoute;
-  '/llm-context': typeof LlmContextRoute;
-  '/og': typeof OgRoute;
-  '/sitemap.xml': typeof SitemapDotxmlRoute;
-  '/blog/$': typeof BlogSplatRoute;
-  '/clients/$': typeof ClientsSplatRoute;
-  '/lab/$slug': typeof LabSlugRoute;
-  '/labs/$': typeof LabsSplatRoute;
-  '/portfolio/$': typeof PortfolioSplatRoute;
-  '/projects/$': typeof ProjectsSplatRoute;
-  '/snippets/$': typeof SnippetsSplatRoute;
-  '/tag/$slug': typeof TagSlugRoute;
-  '/blog': typeof BlogIndexRoute;
-  '/clients': typeof ClientsIndexRoute;
-  '/lab': typeof LabIndexRoute;
-  '/labs': typeof LabsIndexRoute;
-  '/photography': typeof PhotographyIndexRoute;
-  '/portfolio': typeof PortfolioIndexRoute;
-  '/projects': typeof ProjectsIndexRoute;
-  '/snippets': typeof SnippetsIndexRoute;
-  '/photography/photo/$': typeof PhotographyPhotoSplatRoute;
-  '/lab/co2': typeof LabCo2IndexRoute;
-  '/lab/gen-art-gallery': typeof LabGenArtGalleryIndexRoute;
-  '/lab/ons-land': typeof LabOnsLandIndexRoute;
-  '/lab/prognosis-2100': typeof LabPrognosis2100IndexRoute;
+  '/': typeof IndexRoute
+  '/about': typeof AboutRoute
+  '/feed.xml': typeof FeedDotxmlRoute
+  '/health': typeof HealthRoute
+  '/llm-context': typeof LlmContextRoute
+  '/og': typeof OgRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/blog/$': typeof BlogSplatRoute
+  '/clients/$': typeof ClientsSplatRoute
+  '/lab/$slug': typeof LabSlugRoute
+  '/labs/$': typeof LabsSplatRoute
+  '/portfolio/$': typeof PortfolioSplatRoute
+  '/projects/$': typeof ProjectsSplatRoute
+  '/snippets/$': typeof SnippetsSplatRoute
+  '/tag/$slug': typeof TagSlugRoute
+  '/blog': typeof BlogIndexRoute
+  '/clients': typeof ClientsIndexRoute
+  '/lab': typeof LabIndexRoute
+  '/labs': typeof LabsIndexRoute
+  '/photography': typeof PhotographyIndexRoute
+  '/portfolio': typeof PortfolioIndexRoute
+  '/projects': typeof ProjectsIndexRoute
+  '/snippets': typeof SnippetsIndexRoute
+  '/photography/photo/$': typeof PhotographyPhotoSplatRoute
+  '/lab/co2': typeof LabCo2IndexRoute
+  '/lab/gen-art-gallery': typeof LabGenArtGalleryIndexRoute
+  '/lab/ons-land': typeof LabOnsLandIndexRoute
+  '/lab/prognosis-2100': typeof LabPrognosis2100IndexRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  '/': typeof IndexRoute;
-  '/about': typeof AboutRoute;
-  '/feed.xml': typeof FeedDotxmlRoute;
-  '/health': typeof HealthRoute;
-  '/llm-context': typeof LlmContextRoute;
-  '/og': typeof OgRoute;
-  '/sitemap.xml': typeof SitemapDotxmlRoute;
-  '/blog/$': typeof BlogSplatRoute;
-  '/clients/$': typeof ClientsSplatRoute;
-  '/lab/$slug': typeof LabSlugRoute;
-  '/labs/$': typeof LabsSplatRoute;
-  '/portfolio/$': typeof PortfolioSplatRoute;
-  '/projects/$': typeof ProjectsSplatRoute;
-  '/snippets/$': typeof SnippetsSplatRoute;
-  '/tag/$slug': typeof TagSlugRoute;
-  '/blog/': typeof BlogIndexRoute;
-  '/clients/': typeof ClientsIndexRoute;
-  '/lab/': typeof LabIndexRoute;
-  '/labs/': typeof LabsIndexRoute;
-  '/photography/': typeof PhotographyIndexRoute;
-  '/portfolio/': typeof PortfolioIndexRoute;
-  '/projects/': typeof ProjectsIndexRoute;
-  '/snippets/': typeof SnippetsIndexRoute;
-  '/photography/photo/$': typeof PhotographyPhotoSplatRoute;
-  '/lab/co2/': typeof LabCo2IndexRoute;
-  '/lab/gen-art-gallery/': typeof LabGenArtGalleryIndexRoute;
-  '/lab/ons-land/': typeof LabOnsLandIndexRoute;
-  '/lab/prognosis-2100/': typeof LabPrognosis2100IndexRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/about': typeof AboutRoute
+  '/feed.xml': typeof FeedDotxmlRoute
+  '/health': typeof HealthRoute
+  '/llm-context': typeof LlmContextRoute
+  '/og': typeof OgRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/blog/$': typeof BlogSplatRoute
+  '/clients/$': typeof ClientsSplatRoute
+  '/lab/$slug': typeof LabSlugRoute
+  '/labs/$': typeof LabsSplatRoute
+  '/portfolio/$': typeof PortfolioSplatRoute
+  '/projects/$': typeof ProjectsSplatRoute
+  '/snippets/$': typeof SnippetsSplatRoute
+  '/tag/$slug': typeof TagSlugRoute
+  '/blog/': typeof BlogIndexRoute
+  '/clients/': typeof ClientsIndexRoute
+  '/lab/': typeof LabIndexRoute
+  '/labs/': typeof LabsIndexRoute
+  '/photography/': typeof PhotographyIndexRoute
+  '/portfolio/': typeof PortfolioIndexRoute
+  '/projects/': typeof ProjectsIndexRoute
+  '/snippets/': typeof SnippetsIndexRoute
+  '/photography/photo/$': typeof PhotographyPhotoSplatRoute
+  '/lab/co2/': typeof LabCo2IndexRoute
+  '/lab/gen-art-gallery/': typeof LabGenArtGalleryIndexRoute
+  '/lab/ons-land/': typeof LabOnsLandIndexRoute
+  '/lab/prognosis-2100/': typeof LabPrognosis2100IndexRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/about'
@@ -300,8 +300,8 @@ export interface FileRouteTypes {
     | '/lab/co2/'
     | '/lab/gen-art-gallery/'
     | '/lab/ons-land/'
-    | '/lab/prognosis-2100/';
-  fileRoutesByTo: FileRoutesByTo;
+    | '/lab/prognosis-2100/'
+  fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/about'
@@ -330,7 +330,7 @@ export interface FileRouteTypes {
     | '/lab/co2'
     | '/lab/gen-art-gallery'
     | '/lab/ons-land'
-    | '/lab/prognosis-2100';
+    | '/lab/prognosis-2100'
   id:
     | '__root__'
     | '/'
@@ -360,238 +360,238 @@ export interface FileRouteTypes {
     | '/lab/co2/'
     | '/lab/gen-art-gallery/'
     | '/lab/ons-land/'
-    | '/lab/prognosis-2100/';
-  fileRoutesById: FileRoutesById;
+    | '/lab/prognosis-2100/'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  AboutRoute: typeof AboutRoute;
-  FeedDotxmlRoute: typeof FeedDotxmlRoute;
-  HealthRoute: typeof HealthRoute;
-  LlmContextRoute: typeof LlmContextRoute;
-  OgRoute: typeof OgRoute;
-  SitemapDotxmlRoute: typeof SitemapDotxmlRoute;
-  BlogSplatRoute: typeof BlogSplatRoute;
-  ClientsSplatRoute: typeof ClientsSplatRoute;
-  LabSlugRoute: typeof LabSlugRoute;
-  LabsSplatRoute: typeof LabsSplatRoute;
-  PortfolioSplatRoute: typeof PortfolioSplatRoute;
-  ProjectsSplatRoute: typeof ProjectsSplatRoute;
-  SnippetsSplatRoute: typeof SnippetsSplatRoute;
-  TagSlugRoute: typeof TagSlugRoute;
-  BlogIndexRoute: typeof BlogIndexRoute;
-  ClientsIndexRoute: typeof ClientsIndexRoute;
-  LabIndexRoute: typeof LabIndexRoute;
-  LabsIndexRoute: typeof LabsIndexRoute;
-  PhotographyIndexRoute: typeof PhotographyIndexRoute;
-  PortfolioIndexRoute: typeof PortfolioIndexRoute;
-  ProjectsIndexRoute: typeof ProjectsIndexRoute;
-  SnippetsIndexRoute: typeof SnippetsIndexRoute;
-  PhotographyPhotoSplatRoute: typeof PhotographyPhotoSplatRoute;
-  LabCo2IndexRoute: typeof LabCo2IndexRoute;
-  LabGenArtGalleryIndexRoute: typeof LabGenArtGalleryIndexRoute;
-  LabOnsLandIndexRoute: typeof LabOnsLandIndexRoute;
-  LabPrognosis2100IndexRoute: typeof LabPrognosis2100IndexRoute;
+  IndexRoute: typeof IndexRoute
+  AboutRoute: typeof AboutRoute
+  FeedDotxmlRoute: typeof FeedDotxmlRoute
+  HealthRoute: typeof HealthRoute
+  LlmContextRoute: typeof LlmContextRoute
+  OgRoute: typeof OgRoute
+  SitemapDotxmlRoute: typeof SitemapDotxmlRoute
+  BlogSplatRoute: typeof BlogSplatRoute
+  ClientsSplatRoute: typeof ClientsSplatRoute
+  LabSlugRoute: typeof LabSlugRoute
+  LabsSplatRoute: typeof LabsSplatRoute
+  PortfolioSplatRoute: typeof PortfolioSplatRoute
+  ProjectsSplatRoute: typeof ProjectsSplatRoute
+  SnippetsSplatRoute: typeof SnippetsSplatRoute
+  TagSlugRoute: typeof TagSlugRoute
+  BlogIndexRoute: typeof BlogIndexRoute
+  ClientsIndexRoute: typeof ClientsIndexRoute
+  LabIndexRoute: typeof LabIndexRoute
+  LabsIndexRoute: typeof LabsIndexRoute
+  PhotographyIndexRoute: typeof PhotographyIndexRoute
+  PortfolioIndexRoute: typeof PortfolioIndexRoute
+  ProjectsIndexRoute: typeof ProjectsIndexRoute
+  SnippetsIndexRoute: typeof SnippetsIndexRoute
+  PhotographyPhotoSplatRoute: typeof PhotographyPhotoSplatRoute
+  LabCo2IndexRoute: typeof LabCo2IndexRoute
+  LabGenArtGalleryIndexRoute: typeof LabGenArtGalleryIndexRoute
+  LabOnsLandIndexRoute: typeof LabOnsLandIndexRoute
+  LabPrognosis2100IndexRoute: typeof LabPrognosis2100IndexRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/sitemap.xml': {
-      id: '/sitemap.xml';
-      path: '/sitemap.xml';
-      fullPath: '/sitemap.xml';
-      preLoaderRoute: typeof SitemapDotxmlRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/sitemap.xml'
+      path: '/sitemap.xml'
+      fullPath: '/sitemap.xml'
+      preLoaderRoute: typeof SitemapDotxmlRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/og': {
-      id: '/og';
-      path: '/og';
-      fullPath: '/og';
-      preLoaderRoute: typeof OgRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/og'
+      path: '/og'
+      fullPath: '/og'
+      preLoaderRoute: typeof OgRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/llm-context': {
-      id: '/llm-context';
-      path: '/llm-context';
-      fullPath: '/llm-context';
-      preLoaderRoute: typeof LlmContextRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/llm-context'
+      path: '/llm-context'
+      fullPath: '/llm-context'
+      preLoaderRoute: typeof LlmContextRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/health': {
-      id: '/health';
-      path: '/health';
-      fullPath: '/health';
-      preLoaderRoute: typeof HealthRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/health'
+      path: '/health'
+      fullPath: '/health'
+      preLoaderRoute: typeof HealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/feed.xml': {
-      id: '/feed.xml';
-      path: '/feed.xml';
-      fullPath: '/feed.xml';
-      preLoaderRoute: typeof FeedDotxmlRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/feed.xml'
+      path: '/feed.xml'
+      fullPath: '/feed.xml'
+      preLoaderRoute: typeof FeedDotxmlRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/about': {
-      id: '/about';
-      path: '/about';
-      fullPath: '/about';
-      preLoaderRoute: typeof AboutRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
-      id: '/';
-      path: '/';
-      fullPath: '/';
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/snippets/': {
-      id: '/snippets/';
-      path: '/snippets';
-      fullPath: '/snippets/';
-      preLoaderRoute: typeof SnippetsIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/snippets/'
+      path: '/snippets'
+      fullPath: '/snippets/'
+      preLoaderRoute: typeof SnippetsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/projects/': {
-      id: '/projects/';
-      path: '/projects';
-      fullPath: '/projects/';
-      preLoaderRoute: typeof ProjectsIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/projects/'
+      path: '/projects'
+      fullPath: '/projects/'
+      preLoaderRoute: typeof ProjectsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/portfolio/': {
-      id: '/portfolio/';
-      path: '/portfolio';
-      fullPath: '/portfolio/';
-      preLoaderRoute: typeof PortfolioIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/portfolio/'
+      path: '/portfolio'
+      fullPath: '/portfolio/'
+      preLoaderRoute: typeof PortfolioIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/photography/': {
-      id: '/photography/';
-      path: '/photography';
-      fullPath: '/photography/';
-      preLoaderRoute: typeof PhotographyIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/photography/'
+      path: '/photography'
+      fullPath: '/photography/'
+      preLoaderRoute: typeof PhotographyIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/labs/': {
-      id: '/labs/';
-      path: '/labs';
-      fullPath: '/labs/';
-      preLoaderRoute: typeof LabsIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/labs/'
+      path: '/labs'
+      fullPath: '/labs/'
+      preLoaderRoute: typeof LabsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/lab/': {
-      id: '/lab/';
-      path: '/lab';
-      fullPath: '/lab/';
-      preLoaderRoute: typeof LabIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/lab/'
+      path: '/lab'
+      fullPath: '/lab/'
+      preLoaderRoute: typeof LabIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/clients/': {
-      id: '/clients/';
-      path: '/clients';
-      fullPath: '/clients/';
-      preLoaderRoute: typeof ClientsIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/clients/'
+      path: '/clients'
+      fullPath: '/clients/'
+      preLoaderRoute: typeof ClientsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/blog/': {
-      id: '/blog/';
-      path: '/blog';
-      fullPath: '/blog/';
-      preLoaderRoute: typeof BlogIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/blog/'
+      path: '/blog'
+      fullPath: '/blog/'
+      preLoaderRoute: typeof BlogIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/tag/$slug': {
-      id: '/tag/$slug';
-      path: '/tag/$slug';
-      fullPath: '/tag/$slug';
-      preLoaderRoute: typeof TagSlugRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/tag/$slug'
+      path: '/tag/$slug'
+      fullPath: '/tag/$slug'
+      preLoaderRoute: typeof TagSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/snippets/$': {
-      id: '/snippets/$';
-      path: '/snippets/$';
-      fullPath: '/snippets/$';
-      preLoaderRoute: typeof SnippetsSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/snippets/$'
+      path: '/snippets/$'
+      fullPath: '/snippets/$'
+      preLoaderRoute: typeof SnippetsSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/projects/$': {
-      id: '/projects/$';
-      path: '/projects/$';
-      fullPath: '/projects/$';
-      preLoaderRoute: typeof ProjectsSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/projects/$'
+      path: '/projects/$'
+      fullPath: '/projects/$'
+      preLoaderRoute: typeof ProjectsSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/portfolio/$': {
-      id: '/portfolio/$';
-      path: '/portfolio/$';
-      fullPath: '/portfolio/$';
-      preLoaderRoute: typeof PortfolioSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/portfolio/$'
+      path: '/portfolio/$'
+      fullPath: '/portfolio/$'
+      preLoaderRoute: typeof PortfolioSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/labs/$': {
-      id: '/labs/$';
-      path: '/labs/$';
-      fullPath: '/labs/$';
-      preLoaderRoute: typeof LabsSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/labs/$'
+      path: '/labs/$'
+      fullPath: '/labs/$'
+      preLoaderRoute: typeof LabsSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/lab/$slug': {
-      id: '/lab/$slug';
-      path: '/lab/$slug';
-      fullPath: '/lab/$slug';
-      preLoaderRoute: typeof LabSlugRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/lab/$slug'
+      path: '/lab/$slug'
+      fullPath: '/lab/$slug'
+      preLoaderRoute: typeof LabSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/clients/$': {
-      id: '/clients/$';
-      path: '/clients/$';
-      fullPath: '/clients/$';
-      preLoaderRoute: typeof ClientsSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/clients/$'
+      path: '/clients/$'
+      fullPath: '/clients/$'
+      preLoaderRoute: typeof ClientsSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/blog/$': {
-      id: '/blog/$';
-      path: '/blog/$';
-      fullPath: '/blog/$';
-      preLoaderRoute: typeof BlogSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/blog/$'
+      path: '/blog/$'
+      fullPath: '/blog/$'
+      preLoaderRoute: typeof BlogSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/lab/prognosis-2100/': {
-      id: '/lab/prognosis-2100/';
-      path: '/lab/prognosis-2100';
-      fullPath: '/lab/prognosis-2100/';
-      preLoaderRoute: typeof LabPrognosis2100IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/lab/prognosis-2100/'
+      path: '/lab/prognosis-2100'
+      fullPath: '/lab/prognosis-2100/'
+      preLoaderRoute: typeof LabPrognosis2100IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/lab/ons-land/': {
-      id: '/lab/ons-land/';
-      path: '/lab/ons-land';
-      fullPath: '/lab/ons-land/';
-      preLoaderRoute: typeof LabOnsLandIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/lab/ons-land/'
+      path: '/lab/ons-land'
+      fullPath: '/lab/ons-land/'
+      preLoaderRoute: typeof LabOnsLandIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/lab/gen-art-gallery/': {
-      id: '/lab/gen-art-gallery/';
-      path: '/lab/gen-art-gallery';
-      fullPath: '/lab/gen-art-gallery/';
-      preLoaderRoute: typeof LabGenArtGalleryIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/lab/gen-art-gallery/'
+      path: '/lab/gen-art-gallery'
+      fullPath: '/lab/gen-art-gallery/'
+      preLoaderRoute: typeof LabGenArtGalleryIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/lab/co2/': {
-      id: '/lab/co2/';
-      path: '/lab/co2';
-      fullPath: '/lab/co2/';
-      preLoaderRoute: typeof LabCo2IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/lab/co2/'
+      path: '/lab/co2'
+      fullPath: '/lab/co2/'
+      preLoaderRoute: typeof LabCo2IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/photography/photo/$': {
-      id: '/photography/photo/$';
-      path: '/photography/photo/$';
-      fullPath: '/photography/photo/$';
-      preLoaderRoute: typeof PhotographyPhotoSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/photography/photo/$'
+      path: '/photography/photo/$'
+      fullPath: '/photography/photo/$'
+      preLoaderRoute: typeof PhotographyPhotoSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -623,15 +623,17 @@ const rootRouteChildren: RootRouteChildren = {
   LabCo2IndexRoute: LabCo2IndexRoute,
   LabGenArtGalleryIndexRoute: LabGenArtGalleryIndexRoute,
   LabOnsLandIndexRoute: LabOnsLandIndexRoute,
-  LabPrognosis2100IndexRoute: LabPrognosis2100IndexRoute
-};
-export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>();
+  LabPrognosis2100IndexRoute: LabPrognosis2100IndexRoute,
+}
+export const routeTree = rootRouteImport
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from './router.tsx';
-import type { createStart } from '@tanstack/react-start';
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/src/routes/lab/$slug.tsx
+++ b/src/routes/lab/$slug.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import { createFileRoute, notFound } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { getMdxComponent } from '#/cms/mdx-parser';
+import { Container } from '#/components/layout/Container';
 import { MarkdownLayout } from '#/components/content/MarkdownLayout';
 import { NotFoundPage } from '#/components/content/NotFoundPage';
 
@@ -81,14 +82,16 @@ function PostPage() {
 
 function MarkdownLayoutSkeleton() {
   return (
-    <div className="mx-auto w-full max-w-[700px] animate-pulse">
-      <div className="mb-4 h-8 w-3/4 rounded bg-gray-200 dark:bg-gray-800" />
-      <div className="mb-8 h-4 w-1/2 rounded bg-gray-200 dark:bg-gray-800" />
-      <div className="space-y-3">
-        <div className="h-4 rounded bg-gray-200 dark:bg-gray-800" />
-        <div className="h-4 rounded bg-gray-200 dark:bg-gray-800" />
-        <div className="h-4 w-5/6 rounded bg-gray-200 dark:bg-gray-800" />
+    <Container>
+      <div className="mx-auto w-full max-w-[700px] animate-pulse">
+        <div className="mb-4 h-8 w-3/4 rounded bg-gray-200 dark:bg-gray-800" />
+        <div className="mb-8 h-4 w-1/2 rounded bg-gray-200 dark:bg-gray-800" />
+        <div className="space-y-3">
+          <div className="h-4 rounded bg-gray-200 dark:bg-gray-800" />
+          <div className="h-4 rounded bg-gray-200 dark:bg-gray-800" />
+          <div className="h-4 w-5/6 rounded bg-gray-200 dark:bg-gray-800" />
+        </div>
       </div>
-    </div>
+    </Container>
   );
 }


### PR DESCRIPTION
## Problem

When opening a blog post, the sidebar first appeared centered on the page, then jumped to its correct left position once the MDX content loaded. This was caused by the `MarkdownLayoutSkeleton` (the Suspense fallback) not including the `Container` wrapper — so during MDX loading, the layout chrome (sidebar, header) was missing and the skeleton rendered centered full-width.

## Fix

1. **`src/routes/lab/$slug.tsx`**: Wrap `MarkdownLayoutSkeleton` in `<Container>` so the sidebar is always present during Suspense. The layout structure (sidebar left, content right) is now stable from the first paint.

2. **`src/components/layout/Container.tsx`**: Change `lg:mx-auto` to `md:mx-auto` so the container centers from the md breakpoint — the same breakpoint where the sidebar becomes visible. This prevents left-aligned layout on medium screens.

3. **`README.md`**: Added a "Preventing Layout Shifts" section documenting:
   - Suspense fallbacks must preserve layout structure
   - Reserve space for async content with matching dimensions
   - Always verify with throttled network (Slow 3G)
   - Existing anti-shift measures that must not be removed

## Verification

- `npm run type-check` — passes
- `npm run lint` — passes (pre-existing warning in unrelated file)
- `npm run test` — 33/33 unit tests pass
- `npm run test:e2e` — 28/28 Playwright tests pass