### PR TITLE
fix: remove stale Vite build cache and add dynamic import error recovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ ARG SOURCE_COMMIT=unknown
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN --mount=type=cache,target=/app/node_modules/.cache \
-    SOURCE_COMMIT=${SOURCE_COMMIT} npm run build
+RUN SOURCE_COMMIT=${SOURCE_COMMIT} npm run build
 
 # ---- prod-deps stage: production-only deps (includes native addons) ----
 FROM node:24-alpine AS prod-deps

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -104,7 +104,7 @@ http {
             # Prevent browsers from caching HTML documents. Without this, a browser
             # may serve a stale HTML page (referencing old hashed asset filenames)
             # after a redeploy, causing 404s for JS/CSS bundles that no longer exist.
-            add_header Cache-Control "no-cache" always;
+            add_header Cache-Control "no-cache, must-revalidate" always;
 
             proxy_pass http://nodejs;
             proxy_http_version 1.1;

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -134,6 +134,21 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             `
           }}
         />
+        {/* Auto-reload on dynamic import failures (e.g. stale chunk after redeploy) */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              let _reloading = false;
+              window.addEventListener('error', function(e) {
+                if (_reloading) return;
+                if (e && e.message && /Failed to fetch dynamically imported module/i.test(e.message)) {
+                  _reloading = true;
+                  window.location.reload();
+                }
+              });
+            `
+          }}
+        />
         <div className="flex min-h-screen flex-col">{children}</div>
         <Tracking />
         {DevTools && (


### PR DESCRIPTION
## Problem

After deploys, dynamically imported JS modules (route-level code-split chunks) return 404, causing `TypeError: Failed to fetch dynamically imported module`. The main JS bundle loads successfully, but lazy-loaded route chunks fail.

## Root Cause

The Dockerfile used a BuildKit cache mount (`--mount=type=cache,target=/app/node_modules/.cache`) that persisted Vite's incremental build cache across Docker builds. When this cache became stale, Vite reused cached chunk information from a previous build, producing a main bundle referencing chunks with old hashes that weren't actually produced in the current build.

## Changes

1. **`Dockerfile`** — Removed the BuildKit cache mount for the Vite build. Vite now builds fresh each deploy. The `node_modules` are already cached by the `deps` stage, so the only cost is Vite's internal caching (which caused the bug).

2. **`src/routes/__root.tsx`** — Added an inline `<script>` that catches `Failed to fetch dynamically imported module` errors and reloads the page once (debounced). This provides client-side recovery for any edge case where chunks are still missing.

3. **`nginx/nginx.conf`** — Strengthened `Cache-Control` on SSR responses from `no-cache` to `no-cache, must-revalidate` to also require intermediary proxies to revalidate.