### PR TITLE
fix: auto-reload on stale chunk 404 after deploy

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -138,14 +138,18 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <script
           dangerouslySetInnerHTML={{
             __html: `
-              let _reloading = false;
-              window.addEventListener('error', function(e) {
-                if (_reloading) return;
-                if (e && e.message && /Failed to fetch dynamically imported module/i.test(e.message)) {
-                  _reloading = true;
-                  window.location.reload();
+              (function() {
+                let _reloading = false;
+                function reloadIfChunkError(msg) {
+                  if (_reloading) return;
+                  if (msg && /Failed to fetch dynamically imported module/i.test(msg)) {
+                    _reloading = true;
+                    window.location.reload();
+                  }
                 }
-              });
+                window.addEventListener('error', (e) => reloadIfChunkError(e.message));
+                window.addEventListener('unhandledrejection', (e) => reloadIfChunkError(e.reason?.message));
+              })();
             `
           }}
         />
@@ -164,6 +168,11 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 
 function ErrorPage({ error }: { error: Error }) {
   useEffect(() => {
+    // If a lazy route chunk is missing after a deploy, reload to fetch fresh assets
+    if (/Failed to fetch dynamically imported module/.test(error.message)) {
+      window.location.reload();
+      return;
+    }
     console.error(error);
   }, [error]);
 


### PR DESCRIPTION
## Problem

After deploys, returning visitors with long-lived tabs see 404 errors when trying to load JS/CSS chunks. This happens because:

1. Vite builds hashed chunks into `/assets/`
2. Nginx serves `/assets/` with `immutable` caching (cache forever)
3. On deploy, Coolify replaces the container with a new image containing only new hashed chunks
4. Old tabs still run cached JS entry points that reference chunks which no longer exist on the server
5. TanStack Router lazy-loads missing route chunks \u2192 `404` + `TypeError: Failed to fetch dynamically imported module`

## Solution

Added two recovery mechanisms in `src/routes/__root.tsx`:

1. **Router-level recovery** \u2014 the root `ErrorPage` now detects chunk load failures and reloads the page immediately.
2. **Global safety net** \u2014 an inline script catches any unhandled dynamic import errors outside the router and reloads.

Both use a `reloaded` guard to prevent infinite loops.